### PR TITLE
fix conda env issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,10 @@ channels:
 
 dependencies:
   - python=3.8
+  - pyqt>=5.15
   - pip
-  - opencv
   - scipy
   - pip:
-    - pyqt5
-    - spinnaker-python
+    - pyqtgraph
+    - opencv-python-headless
+#    - spinnaker-python


### PR DESCRIPTION
use headless opencv from pypi (to avoid qt conflicts) 
remove spinnaker until we figure out how to install it 
add pyqtgraph and a specific version pf pyqt