### PR TITLE
Wip/probe calibration

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "0.37.7"
+__version__ = "0.37.8"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/coords_transformation.py
+++ b/parallax/coords_transformation.py
@@ -1,0 +1,66 @@
+import numpy as np
+from scipy.optimize import leastsq
+
+class RotationTransformation:
+    def __init__(self):
+        pass
+
+    def roll(self, inputMat, g):  # rotation around x axis (bank angle)
+        rollMat = np.array([[1, 0, 0],
+                            [0, np.cos(g), -np.sin(g)],
+                            [0, np.sin(g), np.cos(g)]])
+        return np.dot(inputMat, rollMat)
+
+    def pitch(self, inputMat, b):  # rotation around y axis (elevation angle)
+        pitchMat = np.array([[np.cos(b), 0, np.sin(b)],
+                             [0, 1, 0],
+                             [-np.sin(b), 0, np.cos(b)]])
+        return np.dot(inputMat, pitchMat)
+
+    def yaw(self, inputMat, a):  # rotation around z axis (heading angle)
+        yawMat = np.array([[np.cos(a), -np.sin(a), 0],
+                           [np.sin(a), np.cos(a), 0],
+                           [0, 0, 1]])
+        return np.dot(inputMat, yawMat)
+
+    def extractAngles(self, mat):
+        """Extracts roll, pitch, and yaw angles from a rotation matrix mat"""
+        x = np.arctan2(mat[2, 1], mat[2, 2])
+        y = np.arctan2(-mat[2, 0], np.sqrt(pow(mat[2, 1], 2) + pow(mat[2, 2], 2)))
+        z = np.arctan2(mat[1, 0], mat[0, 0])
+        return x, y, z
+
+    def combineAngles(self, x, y, z):
+        """Combines separate roll, pitch, and yaw angles into a single rotation matrix."""
+        eye = np.identity(3)
+        R = self.roll(
+            self.pitch(
+                self.yaw(eye, z), y), x)
+        return R
+
+    def func(self, x, measured_pts, global_pts):
+        """Defines an error function for the optimization, 
+        which calculates the difference 
+        between transformed global points and measured points."""
+        R = self.combineAngles(x[2], x[1], x[0])
+        origin = np.array([x[3], x[4], x[5]]).T
+
+        error_values = np.zeros(len(global_pts) * 3)
+        for i in range(len(global_pts)):
+            global_pt = global_pts[i, :].T
+            measured_pt = measured_pts[i, :].T
+            global_pt_exp = R @ measured_pt + origin
+            error_values[i * 3: (i + 1) * 3] = global_pt - global_pt_exp
+
+        return error_values
+
+    def fit_params(self, measured_pts, global_pts):
+        """Fits parameters to minimize the error defined in func"""
+        x0 = np.array([0, 0, 0, 0, 0, 0])  # initial guess: (x, y, z, x_t, y_t, z_t)
+        if len(measured_pts) < 3 or len(global_pts) < 3:
+            raise ValueError("At least two points are required for optimization.")
+        res = leastsq(self.func, x0, args=(measured_pts, global_pts))
+        rez = res[0]
+        R = self.combineAngles(rez[2], rez[1], rez[0])
+        origin = rez[3:]
+        return origin, R  # translation vector and rotation matrix

--- a/parallax/probe_calibration.py
+++ b/parallax/probe_calibration.py
@@ -48,6 +48,7 @@ class ProbeCalibration(QObject):
         Initializes the ProbeCalibration object with a given stage listener.
         """
         super().__init__()
+        self.transformer = RotationTransformation()
         self.stage_listener = stage_listener
         self.stage_listener.probeCalibRequest.connect(self.update)
         self.stages = {}
@@ -193,8 +194,8 @@ class ProbeCalibration(QObject):
         Returns:
             tuple: Linear regression model and transformation matrix.
         """
-        transformer = RotationTransformation()
-        origin, R = transformer.fit_params(local_points, global_points)
+
+        origin, R = self.transformer.fit_params(local_points, global_points)
         transformation_matrix = np.hstack([R, origin.reshape(-1, 1)])
         transformation_matrix = np.vstack([transformation_matrix, [0, 0, 0, 1]])
 
@@ -364,17 +365,6 @@ class ProbeCalibration(QObject):
         return False
 
     def _update_info_ui(self):
-        """
-        x_diff = self.max_x - self.min_x
-        y_diff = self.max_y - self.min_y
-        z_diff = self.max_z - self.min_z
-        self.transM_info.emit(
-            self.stage.sn,
-            self.transM_LR,
-            self.LR_err_L2_current,
-            np.array([x_diff, y_diff, z_diff]),
-        )
-        """
         sn = self.stage.sn
         if sn is not None and sn in self.stages:
             stage_data = self.stages[sn]

--- a/parallax/probe_calibration.py
+++ b/parallax/probe_calibration.py
@@ -150,7 +150,7 @@ class ProbeCalibration(QObject):
         # Extract local and global points
         local_points = filtered_df[["local_x", "local_y", "local_z"]].values
         global_points = filtered_df[["global_x", "global_y", "global_z"]].values
-        
+
         return local_points, global_points
 
     def _get_transM_LR(self, local_points, global_points):
@@ -205,6 +205,10 @@ class ProbeCalibration(QObject):
         """
         Updates the CSV file with a new set of local and global points from the current stage position.
         """
+        # Check if stage_z_global is under 10 microns
+        if self.stage.stage_z_global < 10:
+            return  # Do not update if condition is met (to avoid noise)
+        
         with open(self.csv_file, "a", newline='') as file:
             writer = csv.writer(file)
             row_data = [

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -689,7 +689,7 @@ class StageWidget(QWidget):
             self.probeCalibration.clear(self.selected_stage_id)
 
         # update global coords. Set  to '-' on UI
-        self.stageListener.requestClearGlobalDataTransformM(sn = sn)  # TODO
+        self.stageListener.requestClearGlobalDataTransformM(sn = sn)
 
     def probe_detect_default_status(self, sn = None):
         """
@@ -941,7 +941,6 @@ class StageWidget(QWidget):
             return
 
         # Save the previous stage's calibration info
-        #if self.moving_stage_id == prev_stage_id: # TODO
         info = self.get_stage_info()
         self.model.add_stage_calib_info(prev_stage_id, info)
         logger.debug(f"Saved stage {prev_stage_id} info: {info}")

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -686,8 +686,9 @@ class StageWidget(QWidget):
  
             self.filter = "no_filter"
             logger.debug(f"filter: {self.filter}")
-            self.probeCalibration.clear(self.selected_stage_id)
 
+        # Reset the probe calibration status
+        self.probeCalibration.clear(self.selected_stage_id)
         # update global coords. Set  to '-' on UI
         self.stageListener.requestClearGlobalDataTransformM(sn = sn)
 


### PR DESCRIPTION
Changes:
1. Transformation matrix is orthogonal. 
2. Remove noisy points (when probe hits the reticle surface, global z coordinate became under 10 um).
3. Bug Fix) problem - when a probe calibration is reset, the logfile(csv) is not cleared.
