### PR TITLE
Wip/get location from visual data

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "0.37.24"
+__version__ = "0.37.25"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/calculator.py
+++ b/parallax/calculator.py
@@ -40,8 +40,8 @@ class Calculator(QWidget):
 
     def _setCurrentReticle(self):
         reticle_name = self.reticle_selector.currentText()
-        if not reticle_name:
-            return        
+        if not reticle_name or "Proj" in reticle_name:
+            return
         # Extract the letter from reticle_name, assuming it has the format "Global coords (A)"
         self.reticle = reticle_name.split('(')[-1].strip(')')
         self._change_global_label()

--- a/parallax/calculator.py
+++ b/parallax/calculator.py
@@ -199,7 +199,7 @@ class Calculator(QWidget):
             # Get offset values, default to global point coordinates if not found
             reticle_offset = np.array([
                 reticle_metadata.get("offset_x", 0),  # Default to 0 if no offset is provided
-                reticle_metadata.get("offset_y", 0), 
+                reticle_metadata.get("offset_y", 0),
                 reticle_metadata.get("offset_z", 0)
             ])
             

--- a/parallax/calibration_camera.py
+++ b/parallax/calibration_camera.py
@@ -194,7 +194,7 @@ class CalibrationCamera:
         Returns:
             tuple: Origin, x-axis, y-axis, z-axis points.
         """
-        axis = np.float32([[3, 0, 0], [0, 3, 0], [0, 0, 3]]).reshape(-1, 3)
+        axis = np.float32([[5, 0, 0], [0, 5, 0], [0, 0, 7]]).reshape(-1, 3)
         # Find the rotation and translation vectors.
         # Output rotation vector (see Rodrigues ) that, together with tvec,
         # brings points from the model coordinate system 

--- a/parallax/camera.py
+++ b/parallax/camera.py
@@ -235,6 +235,8 @@ class PySpinCamera:
             )
             node_pixelformat.SetIntValue(entry_pixelformat_bayerRG8.GetValue())
 
+        self.camera_info()
+        
         # acquisition on initialization
         if VERSION == "V1":
             # begin acquisition

--- a/parallax/model.py
+++ b/parallax/model.py
@@ -1,7 +1,6 @@
 """
 The Model class is the core component for managing cameras, stages, and calibration data.
 """
-
 from PyQt5.QtCore import QObject, pyqtSignal
 from .camera import MockCamera, PySpinCamera, close_cameras, list_cameras
 from .stage_listener import Stage, StageInfo

--- a/parallax/model.py
+++ b/parallax/model.py
@@ -236,6 +236,9 @@ class Model(QObject):
     def add_stereo_instance(self, instance):
         self.stereo_instance = instance
 
+    def reset_stereo_instance(self):
+        self.stereo_instance = None
+
     def add_camera_extrinsic(self, name1, name2, retVal, R, T, E, F):
         """Add camera extrinsic parameters."""
         self.best_camera_pair = [name1, name2]
@@ -244,6 +247,11 @@ class Model(QObject):
     def get_camera_extrinsic(self, name1, name2):
         """Get camera extrinsic parameters."""
         return self.camera_extrinsic.get(name1 + "-" + name2)
+    
+    def reset_camera_extrinsic(self):
+        """Add camera extrinsic parameters."""
+        self.best_camera_pair = None
+        self.camera_extrinsic = {}
 
     def clean(self):
         """Clean up."""

--- a/parallax/model.py
+++ b/parallax/model.py
@@ -48,6 +48,8 @@ class Model(QObject):
         self.pos_x = {}
         self.camera_intrinsic = {}
         self.camera_extrinsic = {}
+        self.stereo_instance = None
+        self.best_camera_pair = None
         self.calibration = None
         self.calibrations = {}
         self.coords_debug = {}
@@ -57,6 +59,9 @@ class Model(QObject):
 
         # Reticle metadata
         self.reticle_metadata = {}
+
+        # clicked pts
+        self.clicked_pts = {}
         
     def add_calibration(self, cal):
         """Add a calibration."""
@@ -142,6 +147,22 @@ class Model(QObject):
         """Reset stage calibration info."""
         self.stages_calib = {}
 
+    def add_pts(self, camera_name, pts):
+        """Add points."""
+        self.clicked_pts[camera_name] = pts
+    
+    def get_pts(self, camera_name):
+        """Get points."""
+        return self.clicked_pts.get(camera_name)
+    
+    def get_cameras_detected_pts(self):
+        """Get cameras that detected the points."""
+        return self.clicked_pts
+    
+    def reset_pts(self):
+        """Reset points."""
+        self.clicked_pts = {}
+
     def add_transform(self, stage_sn, transform, scale):
         """Add transformation matrix between local to global coordinates."""
         self.transforms[stage_sn] = [transform, scale]
@@ -213,8 +234,12 @@ class Model(QObject):
         """Get camera intrinsic parameters."""
         return self.camera_intrinsic.get(camera_name)
 
+    def add_stereo_instance(self, instance):
+        self.stereo_instance = instance
+
     def add_camera_extrinsic(self, name1, name2, retVal, R, T, E, F):
         """Add camera extrinsic parameters."""
+        self.best_camera_pair = [name1, name2]
         self.camera_extrinsic[name1 + "-" + name2] = [retVal, R, T, E, F]
 
     def get_camera_extrinsic(self, name1, name2):

--- a/parallax/probe_calibration.py
+++ b/parallax/probe_calibration.py
@@ -58,9 +58,9 @@ class ProbeCalibration(QObject):
         self.df = None
         self.inliers = []
         self.stage = None
-        """
+        
         self.threshold_min_max = 250 
-        self.threshold_min_max_z = 0
+        self.threshold_min_max_z = 100
         self.LR_err_L2_threshold = 200
         self.threshold_avg_error = 500
         self.threshold_matrix = np.array(
@@ -84,6 +84,7 @@ class ProbeCalibration(QObject):
                 [0.0, 0.0, 0.0, 0.0],
             ]
         )
+        """
         self.model_LR, self.transM_LR, self.transM_LR_prev = None, None, None
         self.origin, self.R, self.scale = None, None, np.array([1, 1, 1])
         self.avg_err = None

--- a/parallax/probe_calibration.py
+++ b/parallax/probe_calibration.py
@@ -58,7 +58,7 @@ class ProbeCalibration(QObject):
         self.df = None
         self.inliers = []
         self.stage = None
-        
+        """
         self.threshold_min_max = 250 
         self.threshold_min_max_z = 100
         self.LR_err_L2_threshold = 200
@@ -84,13 +84,13 @@ class ProbeCalibration(QObject):
                 [0.0, 0.0, 0.0, 0.0],
             ]
         )
-        """
+
         self.model_LR, self.transM_LR, self.transM_LR_prev = None, None, None
         self.origin, self.R, self.scale = None, None, np.array([1, 1, 1])
         self.avg_err = None
         self.last_row = None
         self._create_file()
-
+        
     def reset_calib(self, sn=None):
         """
         Resets calibration to its initial state, clearing any stored min and max values.

--- a/parallax/probe_detect_manager.py
+++ b/parallax/probe_detect_manager.py
@@ -231,7 +231,7 @@ class ProbeDetectManager(QObject):
                 for coords in self.reticle_coords:
                     for point_idx, (x, y) in enumerate(coords):
                         color = self.colormap_reticle[point_idx][0].tolist()
-                        cv2.circle(frame, (x, y), 4, color, -1)
+                        cv2.circle(frame, (x, y), 7, color, -1)
 
             if self.reticle_coords_debug is not None:
                 for point_idx, (x, y) in enumerate(self.reticle_coords_debug[0]):

--- a/parallax/reticle_detect_manager.py
+++ b/parallax/reticle_detect_manager.py
@@ -79,10 +79,10 @@ class ReticleDetectManager(QObject):
                 return frame
             for pixel in x_axis_coords:
                 pt = tuple(pixel)
-                cv2.circle(frame, pt, 7, (255, 255, 0), -1)
+                cv2.circle(frame, pt, 9, (255, 255, 0), -1)
             for pixel in y_axis_coords:
                 pt = tuple(pixel)
-                cv2.circle(frame, pt, 7, (0, 255, 255), -1)
+                cv2.circle(frame, pt, 9, (0, 255, 255), -1)
             return frame
 
         def draw_xyz(self, frame, origin, x, y, z):

--- a/parallax/reticle_metadata.py
+++ b/parallax/reticle_metadata.py
@@ -164,14 +164,17 @@ class ReticleMetadata(QWidget):
         self._update_to_reticle_selector()
 
     def _update_to_reticle_selector(self):
+        print("reticle_metadata::_update_to_reticle_selector")
         self.reticle_selector.clear()
         self.reticle_selector.addItem(f"Global coords")
+        self.reticle_selector.addItem(f"Proj Global coords")
 
         # update dropdown menu with reticle names
         for name in self.groupboxes.keys():
             self.reticle_selector.addItem(f"Global coords ({name})")
 
     def default_reticle_selector(self):
+        print("reticle_metadata::defualt_reticle_selector")
         # Iterate over the added sgroup boxes and remove each one from the layout
         for name, group_box in self.groupboxes.items():
             self.ui.verticalLayout.removeWidget(group_box)

--- a/parallax/reticle_metadata.py
+++ b/parallax/reticle_metadata.py
@@ -177,7 +177,7 @@ class ReticleMetadata(QWidget):
         for name in self.groupboxes.keys():
             self.reticle_selector.addItem(f"Proj Global coords ({name})")
 
-    def default_reticle_selector(self):
+    def default_reticle_selector(self, reticle_detection_status):
         print("reticle_metadata::defualt_reticle_selector")
         # Iterate over the added sgroup boxes and remove each one from the layout
         for name, group_box in self.groupboxes.items():
@@ -194,6 +194,8 @@ class ReticleMetadata(QWidget):
         # Clear and reset the reticle_selector
         self.reticle_selector.clear()
         self.reticle_selector.addItem(f"Global coords")
+        if reticle_detection_status == "accepted":
+            self.reticle_selector.addItem(f"Proj Global coords")
 
     def _update_to_file(self):
         reticle_info_list = []

--- a/parallax/reticle_metadata.py
+++ b/parallax/reticle_metadata.py
@@ -164,7 +164,6 @@ class ReticleMetadata(QWidget):
         self._update_to_reticle_selector()
 
     def _update_to_reticle_selector(self):
-        print("reticle_metadata::_update_to_reticle_selector")
         self.reticle_selector.clear()
         self.reticle_selector.addItem(f"Global coords")
 
@@ -178,7 +177,6 @@ class ReticleMetadata(QWidget):
             self.reticle_selector.addItem(f"Proj Global coords ({name})")
 
     def default_reticle_selector(self, reticle_detection_status):
-        print("reticle_metadata::defualt_reticle_selector")
         # Iterate over the added sgroup boxes and remove each one from the layout
         for name, group_box in self.groupboxes.items():
             self.ui.verticalLayout.removeWidget(group_box)

--- a/parallax/reticle_metadata.py
+++ b/parallax/reticle_metadata.py
@@ -167,11 +167,15 @@ class ReticleMetadata(QWidget):
         print("reticle_metadata::_update_to_reticle_selector")
         self.reticle_selector.clear()
         self.reticle_selector.addItem(f"Global coords")
-        self.reticle_selector.addItem(f"Proj Global coords")
 
         # update dropdown menu with reticle names
         for name in self.groupboxes.keys():
             self.reticle_selector.addItem(f"Global coords ({name})")
+
+        # update dropdown menu with Project reticle names
+        self.reticle_selector.addItem(f"Proj Global coords")
+        for name in self.groupboxes.keys():
+            self.reticle_selector.addItem(f"Proj Global coords ({name})")
 
     def default_reticle_selector(self):
         print("reticle_metadata::defualt_reticle_selector")

--- a/parallax/screen_coords_mapper.py
+++ b/parallax/screen_coords_mapper.py
@@ -47,7 +47,7 @@ class ScreenCoordsMapper():
         
     def add_global_coords_to_dropdown(self):
         self.reticle_selector.addItem(f"Proj Global coords")
-
+        
     def _apply_reticle_adjustments(self, global_pts):
         reticle_metadata = self.model.get_reticle_metadata(self.reticle)
         reticle_rot = reticle_metadata.get("rot", 0)

--- a/parallax/screen_coords_mapper.py
+++ b/parallax/screen_coords_mapper.py
@@ -1,0 +1,71 @@
+import logging
+import numpy as np
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+class ScreenCoordsMapper():
+    def __init__(self, model, camera_name):
+        self.model = model
+        self.camera_name = camera_name
+        self.pos = None
+
+        self.stereo_instance = None
+        self.camA_best, self.camB_best = None, None
+
+    def set_name(self, camera_name):
+        """Set camera name."""
+        self.camera_name = camera_name
+        logger.debug(f"{self.camera_name} set camera name")
+
+    def clicked_position(self, pt):
+        """Get clicked position."""
+        self.pos = pt
+        self._register_pt()
+        global_coords = self._get_global_coords()
+        if global_coords is not None:
+            global_coords = np.round(global_coords, decimals=2)
+            logger.debug(f"  Global coordinates: {global_coords*1000}")
+            print(f"  Global coordinates: {global_coords*1000}")
+
+    def _register_pt(self):
+        """Register the clicked position."""
+        if self.pos is not None:
+            self.model.add_pts(self.camera_name, self.pos)
+
+    def _get_global_coords(self):
+        """Calculate global coordinates based on the best camera pair."""
+        if self.stereo_instance is None:
+            self.stereo_instance = self.model.stereo_instance
+            return None
+
+        if self.camA_best is None or self.camB_best is None:
+            if not self.model.best_camera_pair:
+                return None
+            self.camA_best, self.camB_best = self.model.best_camera_pair
+            if self.camera_name not in [self.camA_best, self.camB_best]:
+                return None
+
+        # Get detected points from cameras
+        cameras_detected_pts = self.model.get_cameras_detected_pts()
+
+        # Ensure both cameras in the best pair have detected points
+        if self.camA_best not in cameras_detected_pts or self.camB_best not in cameras_detected_pts:
+            logger.debug("One or both cameras in the best pair do not have detected points")
+            return None
+
+        # Assign points based on which camera is clicked
+        if self.camera_name == self.camA_best:
+            tip_coordsA = self.pos
+            tip_coordsB = cameras_detected_pts[self.camB_best]
+        elif self.camera_name == self.camB_best:
+            tip_coordsA = cameras_detected_pts[self.camA_best]
+            tip_coordsB = self.pos
+
+        # Calculate global coordinates using stereo instance
+        global_coords = self.stereo_instance.get_global_coords(
+            self.camA_best, tip_coordsA, self.camB_best, tip_coordsB
+        )
+
+        return global_coords
+

--- a/parallax/screen_coords_mapper.py
+++ b/parallax/screen_coords_mapper.py
@@ -5,10 +5,13 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
 class ScreenCoordsMapper():
-    def __init__(self, model, screen_widgets, reticle_selector):
+    def __init__(self, model, screen_widgets, reticle_selector, x, y, z):
         self.model = model
         self.screen_widgets = screen_widgets
         self.reticle_selector = reticle_selector
+        self.ui_x = x
+        self.ui_y = y
+        self.ui_z = z
 
         # Connect each screen_widget's 'selected' signal to a _clicked_position method
         for screen_widget in self.screen_widgets:
@@ -19,9 +22,18 @@ class ScreenCoordsMapper():
         self._register_pt(camera_name, pos)
         global_coords = self._get_global_coords(camera_name, pos)
         if global_coords is not None:
-            global_coords = np.round(global_coords, decimals=2)
-            logger.debug(f"  Global coordinates: {global_coords*1000}")
-            print(f"  Global coordinates: {global_coords*1000}")
+            global_coords = np.round(global_coords*1000, decimals=1)
+            logger.debug(f"  Global coordinates: {global_coords}")
+            print(f"  Global coordinates: {global_coords}")
+
+        if self.reticle_selector.currentText() == "Proj Global coords":
+            self.ui_x.setText(str(global_coords[0]))
+            self.ui_y.setText(str(global_coords[1]))
+            self.ui_z.setText(str(global_coords[2]))
+
+    def add_global_coords_to_dropdown(self):
+        self.reticle_selector.addItem(f"Proj Global coords")
+        pass
 
     def _register_pt(self, camera_name, pos):
         """Register the clicked position."""
@@ -64,5 +76,5 @@ class ScreenCoordsMapper():
             camA_best, tip_coordsA, camB_best, tip_coordsB
         )
 
-        return global_coords
+        return global_coords[0]
 

--- a/parallax/screen_widget.py
+++ b/parallax/screen_widget.py
@@ -73,7 +73,17 @@ class ScreenWidget(pg.GraphicsView):
         self.camera = camera
         self.camera_name = self.get_camera_name()
         self.focochan = None
-
+        
+        # Dynamically set zoom limits based on image size
+        width, height = self.camera.width, self.camera.height
+        if height is not None and width:
+            self.view_box.setLimits(
+                xMin= -width, xMax= width * 2,  # Prevent panning outside image boundaries
+                yMin= -height, yMax= height * 2,
+                maxXRange=width * 10,
+                maxYRange=height * 10
+            )
+        
         # No filter
         self.filter = NoFilter(self.camera_name)
         self.filter.frame_processed.connect(self.set_image_item_from_data)

--- a/parallax/screen_widget.py
+++ b/parallax/screen_widget.py
@@ -16,6 +16,7 @@ from .no_filter import NoFilter
 from .probe_detect_manager import ProbeDetectManager
 from .reticle_detect_manager import ReticleDetectManager
 from .axis_filter import AxisFilter
+from .screen_coords_mapper import ScreenCoordsMapper
 
 # Set logger name
 logger = logging.getLogger(__name__)
@@ -108,7 +109,9 @@ class ScreenWidget(pg.GraphicsView):
             self.set_image_item_from_data
         )
         self.probeDetector.found_coords.connect(self.found_probe_coords)
-        #self.probeDetector.found_coords.connect(self.probe_coords_detected)
+
+        # Coords Mapper from visual data
+        self.screen_coords_mapper = ScreenCoordsMapper(self.model, self.camera_name)
 
         if self.filename:
             self.set_data(cv2.imread(filename, cv2.IMREAD_GRAYSCALE))
@@ -274,6 +277,7 @@ class ScreenWidget(pg.GraphicsView):
 
     def send_clicked_position(self, pos):
         self.axisFilter.clicked_position(pos)
+        self.screen_coords_mapper.clicked_position(pos)
 
     def image_clicked(self, event):
         """
@@ -315,6 +319,7 @@ class ScreenWidget(pg.GraphicsView):
         self.probeDetector.set_name(camera_sn)
         self.axisFilter.set_name(camera_sn)
         self.filter.set_name(camera_sn)
+        self.screen_coords_mapper.set_name(camera_sn)
 
     def run_reticle_detection(self):
         """Run reticle detection by stopping the filter and starting the reticle detector."""

--- a/parallax/stage_ui.py
+++ b/parallax/stage_ui.py
@@ -99,7 +99,6 @@ class StageUI(QWidget):
 
     def setCurrentReticle(self):
         reticle_name = self.ui.reticle_selector.currentText()
-        print("stage_ui::setCurrentReticle: reticle_name: ", reticle_name)
         if not reticle_name:
             return False
         

--- a/parallax/stage_ui.py
+++ b/parallax/stage_ui.py
@@ -119,7 +119,7 @@ class StageUI(QWidget):
                         if self.ui.reticle_metadata is not None:
                             global_pts = np.array([x, y, z])
                             x, y, z = self.ui.reticle_metadata.get_global_coords_with_offset(self.reticle, global_pts)
-                    
+
                     # Update into UI
                     if x is not None and y is not None and z is not None:
                         self.ui.global_coords_x.setText(str(x))

--- a/parallax/stage_ui.py
+++ b/parallax/stage_ui.py
@@ -28,12 +28,8 @@ class StageUI(QWidget):
 
         # Swtich stages
         self.ui.stage_selector.currentIndexChanged.connect(self.updateStageSN)
-        self.ui.stage_selector.currentIndexChanged.connect(
-            self.updateStageLocalCoords
-        )
-        self.ui.stage_selector.currentIndexChanged.connect(
-            self.updateStageGlobalCoords
-        )
+        self.ui.stage_selector.currentIndexChanged.connect(self.updateStageLocalCoords)
+        self.ui.stage_selector.currentIndexChanged.connect(self.updateStageGlobalCoords)
         self.ui.stage_selector.currentIndexChanged.connect(self.sendInfoToStageWidget)
 
         # Swtich Reticle Coordinates (e.g Reticle + No Offset, Reticle + Offset..)
@@ -96,15 +92,17 @@ class StageUI(QWidget):
                 self.ui.local_coords_z.setText(str(self.selected_stage.stage_z))
 
     def updateCurrentReticle(self):
-        self.setCurrentReticle()
-        self.updateStageGlobalCoords()
+        ret = self.setCurrentReticle()
+        if ret:
+            self.updateStageGlobalCoords()
 
     def setCurrentReticle(self):
         reticle_name = self.ui.reticle_selector.currentText()
         if not reticle_name:
-            return
+            return False
         # Extract the letter from reticle_name, assuming it has the format "Global coords (A)"
         self.reticle = reticle_name.split('(')[-1].strip(')')
+        return True
 
     def updateStageGlobalCoords(self):
         """Update the displayed global coordinates of the selected stage."""

--- a/parallax/stage_ui.py
+++ b/parallax/stage_ui.py
@@ -18,6 +18,7 @@ class StageUI(QWidget):
         self.selected_stage = None
         self.model = model
         self.ui = ui
+        self.reticle = "Global coords"
     
         self.update_stage_selector()
         self.updateStageSN()
@@ -98,14 +99,25 @@ class StageUI(QWidget):
 
     def setCurrentReticle(self):
         reticle_name = self.ui.reticle_selector.currentText()
+        print("stage_ui::setCurrentReticle: reticle_name: ", reticle_name)
         if not reticle_name:
             return False
-        # Extract the letter from reticle_name, assuming it has the format "Global coords (A)"
-        self.reticle = reticle_name.split('(')[-1].strip(')')
+        
+        if "Proj" in reticle_name:
+            self.reticle = "Proj"
+            self.updateStageGlobalCoords_default()
+        else:
+            # Extract the letter from reticle_name, assuming it has the format "Global coords (A)"
+            self.reticle = reticle_name.split('(')[-1].strip(')')
         return True
 
     def updateStageGlobalCoords(self):
         """Update the displayed global coordinates of the selected stage."""
+        if self.reticle == "Proj":
+            # Do no update global coordinates if reticle is Proj
+            # Update global coordinates (projection) from screen_coords_mapper
+            return
+        
         stage_id = self.get_current_stage_id()
         if stage_id:
             self.selected_stage = self.model.get_stage(stage_id)

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -21,6 +21,7 @@ from .stage_listener import StageListener
 from .stage_ui import StageUI
 from .calculator import Calculator
 from .reticle_metadata import ReticleMetadata
+from .screen_coords_mapper import ScreenCoordsMapper
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -175,7 +176,10 @@ class StageWidget(QWidget):
 
         # Reticle Button
         self.reticle_metadata_btn.hide()
-        self.reticle_metadata = ReticleMetadata(self.model, self.reticle_selector) 
+        self.reticle_metadata = ReticleMetadata(self.model, self.reticle_selector)
+
+        # Screen Coords Mapper
+        self.screen_coords_mapper = ScreenCoordsMapper(self.model, self.screen_widgets, self.reticle_selector)
 
     def reticle_detection_button_handler(self):
         """

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -142,7 +142,7 @@ class StageWidget(QWidget):
             self.probe_detection_button_handler
         )
         # Start refreshing stage info
-        self.stageListener = StageListener(self.model, self.stageUI)
+        self.stageListener = StageListener(self.model, self.stageUI, self.probeCalibrationLabel)
         self.stageListener.start()
         self.probeCalibration = ProbeCalibration(self.model, self.stageListener)
         # Hide X, Y, and Z Buttons in Probe Detection
@@ -1053,11 +1053,7 @@ class StageWidget(QWidget):
             if not self.viewTrajectory_btn.isVisible():
                 self.viewTrajectory_btn.show()
         else:
-            # If moving stage is not the selected stage, save the calibration info
-            content = (
-                f"<span style='color:yellow;'><small>Moving probe not selected.<br></small></span>"
-            )
-            self.probeCalibrationLabel.setText(content)
+            logger.debug(f"Update probe calib status: {self.moving_stage_id}, {self.selected_stage_id}")
 
     def get_stage_info(self):
         info = {}

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -110,7 +110,7 @@ class StageWidget(QWidget):
 
         # Reticle Widget
         self.reticle_detection_status = (
-            "default"  # options: default, process, detected, accepted, request_axis
+            "default"  # options: default, process, detected, accepted
         )
         self.reticle_calibration_btn.clicked.connect(
             self.reticle_detection_button_handler
@@ -179,7 +179,8 @@ class StageWidget(QWidget):
         self.reticle_metadata = ReticleMetadata(self.model, self.reticle_selector)
 
         # Screen Coords Mapper
-        self.screen_coords_mapper = ScreenCoordsMapper(self.model, self.screen_widgets, self.reticle_selector)
+        self.screen_coords_mapper = ScreenCoordsMapper(self.model, self.screen_widgets, \
+                self.reticle_selector, self.global_coords_x, self.global_coords_y, self.global_coords_z)
 
     def reticle_detection_button_handler(self):
         """
@@ -382,7 +383,10 @@ class StageWidget(QWidget):
             self.enable_reticle_probe_calibration_buttons()
             logger.debug("Positive x-axis detected on all screens.")
             for screen in self.screen_widgets:
-                screen.run_no_filter()  
+                screen.run_no_filter()
+
+            # Add Global coords to the Global coords dropdown
+            self.screen_coords_mapper.add_global_coords_to_dropdown()
         else:
             self.coords_detected_screens = self.get_coords_detected_screens()
             logger.debug("Checking again for user input of positive x-axis...")

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -811,8 +811,8 @@ class StageWidget(QWidget):
         self.transM, self.L2_err, self.dist_travled = None, None, None
         self.scale = np.array([1, 1, 1])
         self.probeCalibration.reset_calib(sn = sn)
-        self.probe_detect_default_status_ui(sn = sn)
         self.reticle_metadata.default_reticle_selector()
+        self.probe_detect_default_status_ui(sn = sn)
 
     def probe_detect_process_status(self):
         """

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -493,6 +493,7 @@ class StageWidget(QWidget):
                     itmxA_best, itmxB_best = itmxA, itmxB
                     
         # Update the model with the calibration results
+        self.model.add_stereo_instance(self.calibrationStereo)
         self.model.add_camera_extrinsic(
             self.camA_best, self.camB_best, min_err, R_AB_best, T_AB_best, E_AB_best, F_AB_best
         )

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -821,7 +821,7 @@ class StageWidget(QWidget):
         self.transM, self.L2_err, self.dist_travled = None, None, None
         self.scale = np.array([1, 1, 1])
         self.probeCalibration.reset_calib(sn = sn)
-        self.reticle_metadata.default_reticle_selector()
+        self.reticle_metadata.default_reticle_selector(self.reticle_detection_status)
         self.probe_detect_default_status_ui(sn = sn)
 
     def probe_detect_process_status(self):

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -245,6 +245,8 @@ class StageWidget(QWidget):
             # Disable probe calibration
             self.probe_detect_default_status()
         self.model.reset_stage_calib_info()
+        self.model.reset_stereo_instance()
+        self.model.reset_camera_extrinsic()
         self.probeCalibration.clear()
 
     def reticle_overwrite_popup_window(self):

--- a/ui/calc.ui
+++ b/ui/calc.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>819</width>
-    <height>653</height>
+    <width>890</width>
+    <height>347</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,7 +46,7 @@ QPushButton#startButton:disabled:!checked {
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>781</width>
+     <width>861</width>
      <height>621</height>
     </rect>
    </property>
@@ -70,7 +70,7 @@ QPushButton#startButton:disabled:!checked {
 }</string>
         </property>
         <property name="text">
-         <string>     Global </string>
+         <string> Global</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -86,7 +86,7 @@ QPushButton#startButton:disabled:!checked {
          </size>
         </property>
         <property name="text">
-         <string>Local</string>
+         <string>Local    </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -105,7 +105,7 @@ QPushButton#startButton:disabled:!checked {
 }</string>
         </property>
         <property name="text">
-         <string>     (x, y, z)</string>
+         <string>  (x, y, z)</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -115,7 +115,7 @@ QPushButton#startButton:disabled:!checked {
       <item>
        <widget class="QLabel" name="labelGlobalXYZ_2">
         <property name="text">
-         <string>(x, y, z)</string>
+         <string>(x, y, z)   </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>

--- a/ui/calc_QGroupBox.ui
+++ b/ui/calc_QGroupBox.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>803</width>
+    <width>829</width>
     <height>123</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>700</width>
+    <width>750</width>
     <height>100</height>
    </size>
   </property>
@@ -224,6 +224,30 @@ QPushButton#startButton:disabled:!checked {
     <font>
      <pointsize>8</pointsize>
     </font>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="ClearBtn">
+   <property name="geometry">
+    <rect>
+     <x>750</x>
+     <y>50</y>
+     <width>61</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>40</width>
+     <height>0</height>
+    </size>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>7</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Clear</string>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
Updates:
**1. Getting Global Coordinates from Visual Data:**

  - First, click on the reticle metadata. The (Proj)_reticle will display the global coordinates derived from the images.
  ![image](https://github.com/user-attachments/assets/71452fb6-b9af-497b-9ad7-a6f9e282e5cd)
  - Next, click on the image from the stereo view. It will then show the corresponding global coordinates.
  ![image](https://github.com/user-attachments/assets/3fe5d63b-a140-41b2-9ab6-540e5e07bf8b)

**2. Implemented 'Clear Function' in Calculator:** 
  ![image](https://github.com/user-attachments/assets/9b69c1cc-c01c-4046-a6db-6038f829e237)

**3. Bug fix**
- Zoom Out Bug: Previously, zooming out too far would cause the camera screen to disappear from view. Now, there is a limit on how far a user can zoom out, ensuring the camera screen remains visible at all times.
- Global Coordinates Reset: Before, global coordinates would still be displayed after the user cleared the probe calibration. Now, in such cases, the coordinates show as (-, -, -) to reflect the cleared state.
- Stage Mismatch During Probe Calibration: Previously, if an incorrect stage was moved during probe calibration, the information would still update, and the x, y, z calibration buttons would change, which could confuse the user. Now, probe calibration data is only updated when the selected stage and the moving stage are the same.