### PR TITLE
Add preventive codes when there is a camera connection issue

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -17,7 +17,7 @@ from PyQt5.QtWidgets import QFileDialog
 
 # Set logger name
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.WARNING)
 package_dir = os.path.dirname(os.path.abspath(__file__))
 
 


### PR DESCRIPTION
Just in case the camera does not respond, modify the lines below:

1. Add a try-except block around image = self.camera.GetNextImage(1000).

2. Remove while image.IsIncomplete(): time.sleep(0.001).



Referenced from the Spinnaker Programmer's Guide.
<img width="737" alt="image" src="https://github.com/user-attachments/assets/ead014bc-9aba-4bec-9181-fc18ad5b1d90" />

