### PR TITLE
Dev

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -501,22 +501,6 @@ class StageListener(QObject):
             probeDetector.enable_calibration(sn)
             # Stop detection when probe is moving
 
-    def set_low_freq_as_high_freq(self, interval=100):
-        """Change the frequency to low."""
-        self.worker.stop()
-        self.worker.LOW_FREQ_INTERVAL = interval
-        self.worker.curr_interval = self.worker.LOW_FREQ_INTERVAL
-        self.worker.start(interval=self.worker.LOW_FREQ_INTERVAL)
-        # print("low_freq: 10 ms")
-
-    def set_low_freq_default(self, interval=1000):
-        """Change the frequency to low."""
-        self.worker.stop()
-        self.worker.LOW_FREQ_INTERVAL = interval
-        self.worker.curr_interval = self.worker.LOW_FREQ_INTERVAL
-        self.worker.start(interval=self.worker.LOW_FREQ_INTERVAL)
-        # print("low_freq: 1000 ms")
-
     def _get_stage_info_json(self, stage):
         """Create a JSON representation of the stage information."""
         sx, sy, sz = stage.stage_x, stage.stage_y, stage.stage_z

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -85,8 +85,8 @@ class Worker(QObject):
     dataChanged = pyqtSignal(dict)      # Emitted when stage data changes.
     stage_moving = pyqtSignal(dict)     # Emitted when a stage is moving.
     stage_not_moving = pyqtSignal(dict)  # Emitted when a stage is not moving.
-    LOW_FREQ_INTERVAL = 1000
-    HIGH_FREQ_INTERVAL = 100
+    LOW_FREQ_INTERVAL = 1000  # Interval for low frequency data fetching (in ms).
+    HIGH_FREQ_INTERVAL = 100  # Interval for high frequency data fetching (in ms).
     IDLE_TIME = 0.5
 
     def __init__(self, url):

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -85,7 +85,7 @@ class Worker(QObject):
     dataChanged = pyqtSignal(dict)      # Emitted when stage data changes.
     stage_moving = pyqtSignal(dict)     # Emitted when a stage is moving.
     stage_not_moving = pyqtSignal(dict)  # Emitted when a stage is not moving.
-    LOW_FREQ_INTERVAL = 1000  # Interval for low frequency data fetching (in ms).
+    LOW_FREQ_INTERVAL = 500  # Interval for low frequency data fetching (in ms).
     HIGH_FREQ_INTERVAL = 100  # Interval for high frequency data fetching (in ms).
     IDLE_TIME = 0.5
 

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -69,9 +69,9 @@ class Stage(QObject):
             self.stage_x_global = None
             self.stage_y_global = None
             self.stage_z_global = None
-            self.relative_pos_x = self.stage_x - stage_info.get("Stage_XOffset", self.stage_x)
-            self.relative_pos_y = self.stage_y - stage_info.get("Stage_YOffset", self.stage_y)
-            self.relative_pos_z = self.stage_z - stage_info.get("Stage_ZOffset", self.stage_z)
+            self.stage_x_offset = stage_info.get("Stage_XOffset", 0) * 1000
+            self.stage_y_offset = stage_info.get("Stage_YOffset", 0) * 1000
+            self.stage_z_offset = 15000 - (stage_info.get("Stage_ZOffset", 0) * 1000)
             self.yaw = None
             self.pitch = None
             self.roll = None
@@ -313,9 +313,9 @@ class StageListener(QObject):
         stage.stage_x = local_x
         stage.stage_y = local_y
         stage.stage_z = local_z
-        stage.relative_pos_x = local_x - probe.get("Stage_XOffset", local_x)
-        stage.relative_pos_y = local_y - probe.get("Stage_YOffset", local_y)
-        stage.relative_pos_z = local_z - probe.get("Stage_ZOffset", local_z)
+        stage.stage_x_offset = probe.get("Stage_XOffset", 0) * 1000  # Convert to um
+        stage.stage_y_offset = probe.get("Stage_YOffset", 0) * 1000  # Convert to um
+        stage.stage_z_offset = 15000 - (probe.get("Stage_ZOffset", 0) * 1000)  # Convert to um
         local_pts = np.array([local_x, local_y, local_z])
         global_pts = self.coordsConverter.local_to_global(sn, local_pts)
         if global_pts is not None:
@@ -550,9 +550,9 @@ class StageListener(QObject):
             "global_X": convert_and_round(stage.stage_x_global),
             "global_Y": convert_and_round(stage.stage_y_global),
             "global_Z": convert_and_round(stage.stage_z_global),
-            "relative_X": convert_and_round(stage.relative_pos_x),
-            "relative_Y": convert_and_round(stage.relative_pos_y),
-            "relative_Z": convert_and_round(stage.relative_pos_z),
+            "relative_X": convert_and_round(stage.stage_x - stage.stage_x_offset),
+            "relative_Y": convert_and_round(stage.stage_y - stage.stage_y_offset),
+            "relative_Z": convert_and_round(stage.stage_z - stage.stage_z_offset),
             "yaw": stage.yaw,
             "pitch": stage.pitch,
             "roll": stage.roll,

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -518,48 +518,30 @@ class StageListener(QObject):
         # print("low_freq: 1000 ms")
 
     def _get_stage_info_json(self, stage):
-        """Create a JSON file for the stage info.
+        """Create a JSON representation of the stage information."""
+        sx, sy, sz = stage.stage_x, stage.stage_y, stage.stage_z
+        gx, gy, gz = stage.stage_x_global, stage.stage_y_global, stage.stage_z_global
+        ox, oy, oz = stage.stage_x_offset, stage.stage_y_offset, stage.stage_z_offset
 
-        Args:
-            stage (Stage): Stage object.
-        """
-        stage_data = None
+        val_mm = lambda v: round(v * 0.001, 4) if v is not None else None
 
-        if stage is None:
-            logger.error("Error: Stage object is None. Cannot save JSON.")
-            return
-
-        if not hasattr(stage, 'sn') or not stage.sn:
-            logger.error("Error: Invalid stage serial number (sn). Cannot save JSON.")
-            return
-
-        # Convert to mm and round to 4 decimal places if the value is not None
-        def convert_and_round(value):
-            """Convert the value from um to mm and round it to 4 decimal places.
-            Args: value (float): The value in um.
-            Returns: float: The value in mm rounded to 4 decimal places.
-            """
-            return round(value * 0.001, 4) if value is not None else None
-
-        stage_data = {
+        return {
             "sn": stage.sn,
             "name": stage.name,
-            "stage_X": convert_and_round(stage.stage_x),    # Unit is um
-            "stage_Y": convert_and_round(stage.stage_y),
-            "stage_Z": convert_and_round(stage.stage_z),
-            "global_X": convert_and_round(stage.stage_x_global),
-            "global_Y": convert_and_round(stage.stage_y_global),
-            "global_Z": convert_and_round(stage.stage_z_global),
-            "relative_X": convert_and_round(stage.stage_x - stage.stage_x_offset),
-            "relative_Y": convert_and_round(stage.stage_y - stage.stage_y_offset),
-            "relative_Z": convert_and_round(stage.stage_z - stage.stage_z_offset),
+            "stage_X": val_mm(sx),
+            "stage_Y": val_mm(sy),
+            "stage_Z": val_mm(sz),
+            "global_X": val_mm(gx),
+            "global_Y": val_mm(gy),
+            "global_Z": val_mm(gz),
+            "relative_X": val_mm(sx - ox),
+            "relative_Y": val_mm(sy - oy),
+            "relative_Z": val_mm(sz - oz),
             "yaw": stage.yaw,
             "pitch": stage.pitch,
             "roll": stage.roll,
-            "shank_cnt": stage.shank_cnt
+            "shank_cnt": stage.shank_cnt,
         }
-
-        return stage_data
 
     def _snapshot_stage(self):
         """Snapshot the current stage info. Handler for the stage snapshot button."""

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -154,19 +154,20 @@ class Worker(QObject):
             if data is None:
                 return
 
-            self.emit_all_stages(data) # Update all stages
-            change_detected = self._is_any_stage_move(data) # Check if there is any significant change
+            self.emit_all_stages(data)  # Update all stages
+            change_detected = self._is_any_stage_move(data)  # Check if there is any significant change
 
-            if (not change_detected
-                    and self.curr_interval == self.HIGH_FREQ_INTERVAL
-                    and time.time() - self.last_move_detected_time >= self.IDLE_TIME
-                ):
+            if (
+                not change_detected
+                and self.curr_interval == self.HIGH_FREQ_INTERVAL
+                and time.time() - self.last_move_detected_time >= self.IDLE_TIME
+            ):
                 # If stage is not moving for idle_time, switch to low freq mode
-                 logger.debug("low freq mode")
-                 self.curr_interval = self.LOW_FREQ_INTERVAL
-                 self.stop()
-                 self.start(interval=self.curr_interval)
-                 self.stage_not_moving.emit(data["ProbeArray"][data["SelectedProbe"]])
+                logger.debug("low freq mode")
+                self.curr_interval = self.LOW_FREQ_INTERVAL
+                self.stop()
+                self.start(interval=self.curr_interval)
+                self.stage_not_moving.emit(data["ProbeArray"][data["SelectedProbe"]])
 
             if change_detected and self.curr_interval == self.LOW_FREQ_INTERVAL:
                 # Swith to high freq mode
@@ -301,7 +302,6 @@ class StageListener(QObject):
             probe (dict): Probe data.
         """
         sn = probe["SerialNumber"]
-        #print("handleDataChange: ", sn)
         local_coords_x = round(probe.get("Stage_X", 0) * 1000, 1)
         local_coords_y = round(probe.get("Stage_Y", 0) * 1000, 1)
         local_coords_z = 15000 - round(probe.get("Stage_Z", 0) * 1000, 1)

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -487,7 +487,6 @@ class StageListener(QObject):
         for probeDetector in self.model.probeDetectors:
             probeDetector.start_detection(sn)  # Detect when probe is moving
             probeDetector.disable_calibration(sn)
-            # probeDetector.stop_detection(sn) # Detect when probe is not moving
 
     def stageNotMovingStatus(self, probe):
         """Handle not moving probe status.
@@ -497,9 +496,7 @@ class StageListener(QObject):
         """
         sn = probe["SerialNumber"]
         for probeDetector in self.model.probeDetectors:
-            # probeDetector.stop_detection(sn) # Stop detection when probe is not moving
             probeDetector.enable_calibration(sn)
-            # Stop detection when probe is moving
 
     def _get_stage_info_json(self, stage):
         """Create a JSON representation of the stage information."""

--- a/parallax/stage_listener.py
+++ b/parallax/stage_listener.py
@@ -132,6 +132,10 @@ class Worker(QObject):
         print("3. Click 'Connect' on New Scale SW")
 
     def get_data(self):
+        """Fetch data from the URL.
+        Returns:
+            dict: JSON data from the server.
+        """
         response = requests.get(self.url, timeout=1)
         if response.status_code != 200:
             print(f"Failed to access {self.url}. Status code: {response.status_code}")
@@ -190,6 +194,12 @@ class Worker(QObject):
                 self._print_trouble_shooting_msg()
 
     def _is_any_stage_move(self, data):
+        """Check if any stage has moved significantly.
+        Args:
+            data (dict): JSON data from the server.
+        Returns:
+            bool: True if any stage has moved significantly, False otherwise.
+        """
         for stage in data["ProbeArray"]:
             stage_sn = stage["SerialNumber"]
             curr_pos = (stage["Stage_X"], stage["Stage_Y"], stage["Stage_Z"])
@@ -208,6 +218,7 @@ class Worker(QObject):
             self.dataChanged.emit(stage)
 
     def update_into_stages(self, data):
+        """Update the stage data into the model."""
         for stage in data["ProbeArray"]:
             self.stages[stage["SerialNumber"]] = [stage["Stage_X"], stage["Stage_Y"], stage["Stage_Z"]]
 
@@ -302,7 +313,7 @@ class StageListener(QObject):
             probe (dict): Probe data.
         """
         sn = probe["SerialNumber"]
-        stage = self.model.stages.get(sn) # Check if the stage is in the model's stages
+        stage = self.model.stages.get(sn)  # Check if the stage is in the model's stages
         if stage is None:
             return
 
@@ -504,20 +515,22 @@ class StageListener(QObject):
         gx, gy, gz = stage.stage_x_global, stage.stage_y_global, stage.stage_z_global
         ox, oy, oz = stage.stage_x_offset, stage.stage_y_offset, stage.stage_z_offset
 
-        val_mm = lambda v: round(v * 0.001, 4) if v is not None else None
+        def _val_mm(v):
+            """Convert value to mm."""
+            return round(v * 0.001, 4) if v is not None else None
 
         return {
             "sn": stage.sn,
             "name": stage.name,
-            "stage_X": val_mm(sx),
-            "stage_Y": val_mm(sy),
-            "stage_Z": val_mm(sz),
-            "global_X": val_mm(gx),
-            "global_Y": val_mm(gy),
-            "global_Z": val_mm(gz),
-            "relative_X": val_mm(sx - ox),
-            "relative_Y": val_mm(sy - oy),
-            "relative_Z": val_mm(sz - oz),
+            "stage_X": _val_mm(sx),
+            "stage_Y": _val_mm(sy),
+            "stage_Z": _val_mm(sz),
+            "global_X": _val_mm(gx),
+            "global_Y": _val_mm(gy),
+            "global_Z": _val_mm(gz),
+            "relative_X": _val_mm(sx - ox),
+            "relative_Y": _val_mm(sy - oy),
+            "relative_Z": _val_mm(sz - oz),
             "yaw": stage.yaw,
             "pitch": stage.pitch,
             "roll": stage.roll,

--- a/parallax/stage_widget.py
+++ b/parallax/stage_widget.py
@@ -985,7 +985,6 @@ class StageWidget(QWidget):
                 logger.debug(f"Disconnect probe_detection: {camera_name}")
                 screen.run_no_filter()
 
-            self.stageListener.set_low_freq_default()
             self.filter = "no_filter"
             logger.debug(f"filter: {self.filter}")
 
@@ -1047,7 +1046,6 @@ class StageWidget(QWidget):
             else:
                 screen.run_no_filter()
         self.filter = "probe_detection"
-        self.stageListener.set_low_freq_as_high_freq()
         logger.debug(f"filter: {self.filter}")
 
         # message
@@ -1095,7 +1093,6 @@ class StageWidget(QWidget):
                     screen.run_no_filter()
 
             self.filter = "no_filter"
-            self.stageListener.set_low_freq_default()
             logger.debug(f"filter: {self.filter}")
 
         # Update reticle selector


### PR DESCRIPTION
**Updates**
--- 
### Stage Listener

1. Update **ALL** stages in the thread loop.
Previously, only the moving stage was updated under the assumption that only the Pathfinder software controls the stage. However, since external software like Pinpoint can also control the stage and update relative coordinate information without selecting the moving stage, all stages should now be updated periodically.

2. Parse the X, Y, Z offset information to display relative coordinates on the HTTP server and in the Save button.

Example:
<img width="354" alt="image" src="https://github.com/user-attachments/assets/5e5917a8-2a79-40e4-adcd-344394d2819f" />


--- 
### Stage Controller

1. Bugfix: Previously, when the calculator triggered a new move command while a previous move was still in progress, the new request was accepted without properly stopping the existing QTimer instance. As a result, the old timer continued to run in the background and kept executing the previous move logic, causing old motion commands to be sent to the stage. This update instantiate QTimer only once and reuse it. If a new move request comes in while a QTimer is still active, the timer is explicitly stopped before proceeding with the new request to guarantee that only the most recent move command is executed.

