### PR TITLE
Change the usage of sfm

### DIFF
--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dev
 
 jobs:
   build-and-release:

--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
   build-and-release:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please review their [license](https://github.com/magicleap/SuperGluePretrainedNe
 Manual Setup Instructions
 Clone the repository into the external/ folder in your Parallax project root:
 ```bash
-pip install parallax-app[sfm]
+pip install git+https://github.com/AllenNeuralDynamics/sfm.git@main
 git clone https://github.com/magicleap/SuperGluePretrainedNetwork.git external/SuperGluePretrainedNetwork
 ```
 Verify your folder structure looks like this:

--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.8.0"
+__version__ = "1.8.0.dev0"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.8.0.dev0"
+__version__ = "1.8.0.dev1"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.8.0.dev1"
+__version__ = "1.8.1"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ readme = {file = "README.md"}
 [project.optional-dependencies]
 dev = ['parallax-app[linters]']
 camera = ["spinnaker-python"]
-sfm = ["sfm @ git+https://github.com/AllenNeuralDynamics/sfm.git@main"]
 
 linters = [
     'codespell',


### PR DESCRIPTION
To use (sfm = ["sfm @ git+[https://github.com/AllenNeuralDynamics/sfm.git@main"]] in toml file, 'sfm' project should be in PyPI. Will update 'sfm' into PyPI later. 

For now, changed the usage of 'sfm' (pip install git+https://github.com/AllenNeuralDynamics/sfm.git@main) and instruction is in ReadME