### PR TITLE
Python 3.8->3.10, Qt5-> Qt6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           
       # Step 3: Install dependencies (including Sphinx)
       - name: Install Dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/tag_and_publish.yml
+++ b/.github/workflows/tag_and_publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2  
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Extract version from the package
         id: get_version
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           
       # Step 3: Install dependencies (including Sphinx)
       - name: Install Dependencies

--- a/README.md
+++ b/README.md
@@ -12,15 +12,14 @@ setting up and performing acute *in vivo* electrophysiology experiments.
 [Anaconda](https://www.anaconda.com/products/individual) or 
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html))
   -  Python 3.8 is required for the Spinnaker library.
-- PySpin (for Linux or Mac OS users)
-- [Spinnaker SDK](https://www.teledynevisionsolutions.com/products/spinnaker-sdk)
+- [Spinnaker SDK 4.2](https://www.teledynevisionsolutions.com/products/spinnaker-sdk)
 
 
 ### Installation
 1. Create a virtual environment with **Python 3.8** and activate it:
 - On Windows:
 ```bash
-conda create -n parallax python=3.8
+conda create -n parallax python=3.10
 conda activate parallax
 ```
 
@@ -34,9 +33,11 @@ To upgrade to the latest version, run:
 pip install parallax-app --upgrade
 ```
 
-3. To install the camera interface:
+3. Install the camera interface (Spinnaker Python)
+Install from the **wheel file** that comes with the Spinnaker SDK. Replace **<WHEEL_PATH>** with the *full path* to your `.whl`:
+
 ```bash
-pip install parallax-app[camera]
+pip install "<WHEEL_PATH>"
 ```
 
 #### Additional Setup for Linux and macOS

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ setting up and performing acute *in vivo* electrophysiology experiments.
 **Documentation**: [parallax.readthedocs.io](https://parallax.readthedocs.io/en/latest/index.html).
 
 ### Prerequisites
-- **Python==3.8** (Recommended to install via 
+- **Python==3.10** (Recommended to install via
 [Anaconda](https://www.anaconda.com/products/individual) or 
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html))
-  -  Python 3.8 is required for the Spinnaker library.
+  -  Python 3.10 is required for the Spinnaker library.
 - [Spinnaker SDK 4.2](https://www.teledynevisionsolutions.com/products/spinnaker-sdk)
 
 
 ### Installation
-1. Create a virtual environment with **Python 3.8** and activate it:
+1. Create a virtual environment with **Python 3.10** and activate it:
 - On Windows:
 ```bash
 conda create -n parallax python=3.10
@@ -34,7 +34,7 @@ pip install parallax-app --upgrade
 ```
 
 3. Install the camera interface (Spinnaker Python)
-Install from the **wheel file** that comes with the Spinnaker SDK. Replace **<WHEEL_PATH>** with the *full path* to your `.whl`:
+Install from the **wheel file** that comes with the Spinnaker SDK ver.4.2. Replace **<WHEEL_PATH>** with the *full path* to your `.whl`:
 
 ```bash
 pip install "<WHEEL_PATH>"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ furo
 docutils
 numpy
 opencv-python
-PyQt5
+PyQt6
 pyqtgraph
 pandas
 scipy

--- a/parallax/__main__.py
+++ b/parallax/__main__.py
@@ -2,7 +2,7 @@
 Parallax: A GUI application for controlling hardware devices.
 """
 import atexit
-from PyQt5.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication
 from .main_window import MainWindow
 from .model import Model
 from .config.config_path import setup_logging, PARALLAX_ASCII

--- a/parallax/config/user_setting_manager.py
+++ b/parallax/config/user_setting_manager.py
@@ -1,5 +1,5 @@
 """
-Manages user settings for a PyQt5-based application.
+Manages user settings for a PyQt6-based application.
 
 Key Functionalities:
 - Persistent storage of user preferences in a JSON format.

--- a/parallax/control_panel/control_panel.py
+++ b/parallax/control_panel/control_panel.py
@@ -1,15 +1,16 @@
 """
-This module contains the StageWidget class, which is a PyQt5 QWidget subclass for controlling
+This module contains the StageWidget class, which is a PyQt6 QWidget subclass for controlling
 and calibrating stages in microscopy instruments. It interacts with the application's model
 to manage calibration data and provides UI functionalities for reticle and probe detection,
-and camera calibration. The class integrates with PyQt5 for the UI, handling UI loading,
+and camera calibration. The class integrates with PyQt6 for the UI, handling UI loading,
 initializing components, and linking user actions to calibration processes.
 """
 
 import logging
 import os
-from PyQt5.QtWidgets import QSizePolicy, QSpacerItem, QWidget, QAction
-from PyQt5.uic import loadUi
+from PyQt6.QtWidgets import QSizePolicy, QSpacerItem, QWidget
+from PyQt6.QtGui import QAction
+from PyQt6.uic import loadUi
 
 from parallax.stages.stage_listener import StageListener
 from parallax.stages.stage_ui import StageUI
@@ -85,9 +86,15 @@ class ControlPanel(QWidget):
         self.stage_status_ui.layout().addWidget(self.probe_calib_handler)  # Add it to the placeholder's layout
 
         # Create a vertical spacer with expanding policy
-        spacer = QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding)
+        spacer = QSpacerItem(
+            20, 40,
+            QSizePolicy.Policy.Minimum,
+            QSizePolicy.Policy.Expanding
+        )
+
         # Add the spacer to the layout
-        self.stage_status_ui.addItem(spacer)
+        self.stage_status_ui.layout().addItem(spacer)
+        #self.stage_status_ui.addItem(spacer)
 
         # Screen Coords Mapper
         self.screen_coords_mapper = ScreenCoordsMapper(self.model, self.screen_widgets,

--- a/parallax/control_panel/probe_calibration_handler.py
+++ b/parallax/control_panel/probe_calibration_handler.py
@@ -3,9 +3,10 @@ import logging
 import os
 import numpy as np
 from dataclasses import dataclass
-from PyQt5.uic import loadUi
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QLabel, QMessageBox, QPushButton, QWidget, QAction
+from PyQt6.uic import loadUi
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QLabel, QMessageBox, QPushButton, QWidget
+from PyQt6.QtGui import QAction
 from parallax.config.config_path import ui_dir
 from typing import Optional
 
@@ -87,7 +88,9 @@ class ProbeCalibrationHandler(QWidget):
         self.probeCalibrationLabel = self.findChild(
             QLabel, "probeCalibrationLabel"
         )
-        self.probeCalibrationLabel.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.probeCalibrationLabel.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         self.viewTrajectory_btn = self.findChild(QPushButton, "viewTrajectory_btn")
         self.viewTrajectory_btn.clicked.connect(self.view_trajectory_button_handler)
         if self.actionTrajectory is not None:

--- a/parallax/control_panel/probe_calibration_handler.py
+++ b/parallax/control_panel/probe_calibration_handler.py
@@ -313,12 +313,12 @@ class ProbeCalibrationHandler(QWidget):
             self,
             "Probe Detection",
             message,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
         # Check which button was clicked
-        if response == QMessageBox.Yes:
+        if response == QMessageBox.StandardButton.Yes:
             logger.debug("User clicked Yes.")
             return True
         else:

--- a/parallax/control_panel/reticle_detect_handler.py
+++ b/parallax/control_panel/reticle_detect_handler.py
@@ -1,9 +1,10 @@
 """ Reticle detection handler for the Parallax control panel."""
 import logging
 import os
-from PyQt5.QtCore import QTimer, pyqtSignal
-from PyQt5.QtWidgets import QLabel, QMessageBox, QPushButton, QWidget, QAction
-from PyQt5.uic import loadUi
+from PyQt6.QtCore import QTimer, pyqtSignal
+from PyQt6.QtWidgets import QLabel, QMessageBox, QPushButton, QWidget
+from PyQt6.QtGui import QAction
+from PyQt6.uic import loadUi
 from parallax.config.config_path import ui_dir
 from parallax.control_panel.stereo_camera_handler import StereoCameraHandler
 

--- a/parallax/control_panel/reticle_detect_handler.py
+++ b/parallax/control_panel/reticle_detect_handler.py
@@ -222,12 +222,12 @@ class ReticleDetecthandler(QWidget):
             self,
             "Reticle Detection",
             message,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
         # Check which button was clicked
-        if response == QMessageBox.Yes:
+        if response == QMessageBox.StandardButton.Yes:
             logger.debug("User clicked Yes.")
             return True
         else:

--- a/parallax/handlers/calculator.py
+++ b/parallax/handlers/calculator.py
@@ -7,9 +7,9 @@ reticle adjustments, and issuing commands for stage movement.
 import os
 import logging
 import numpy as np
-from PyQt5.QtWidgets import QWidget, QGroupBox, QLineEdit, QPushButton, QLabel, QMessageBox
-from PyQt5.uic import loadUi
-from PyQt5.QtCore import Qt
+from PyQt6.QtWidgets import QWidget, QGroupBox, QLineEdit, QPushButton, QLabel, QMessageBox
+from PyQt6.uic import loadUi
+from PyQt6.QtCore import Qt
 
 from parallax.utils.coords_converter import CoordsConverter
 from parallax.stages.stage_controller import StageController
@@ -43,8 +43,13 @@ class Calculator(QWidget):
 
         self.ui = loadUi(os.path.join(ui_dir, "calc.ui"), self)
         self.setWindowTitle("Calculator")
-        self.setWindowFlags(Qt.Window | Qt.WindowMinimizeButtonHint |
-                            Qt.WindowMaximizeButtonHint | Qt.WindowCloseButtonHint)
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.Window
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint   # include if you want it
+            | Qt.WindowType.WindowCloseButtonHint
+        )
 
         self.add_stage_groupbox()  # Add group boxes for each stage dynamically
         self.reticle_selector.currentIndexChanged.connect(self._setCurrentReticle)

--- a/parallax/handlers/calculator.py
+++ b/parallax/handlers/calculator.py
@@ -307,7 +307,7 @@ class Calculator(QWidget):
 
             # Set the visible title of the QGroupBox to sn
             group_box.setTitle(f"{sn}")
-            group_box.setAlignment(Qt.AlignRight)  # title alignment to the right
+            group_box.setAlignment(Qt.AlignmentFlag.AlignRight)  # title alignment to the right
 
             # Append _{sn} to the QGroupBox object name
             group_box.setObjectName(f"groupBox_{sn}")
@@ -467,10 +467,10 @@ class Calculator(QWidget):
             self,
             "Move Stage Confirmation",
             message,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
-        return response == QMessageBox.Yes
+        return response == QMessageBox.StandardButton.Yes
 
     def _connect_clear_buttons(self):
         """

--- a/parallax/handlers/point_mesh.py
+++ b/parallax/handlers/point_mesh.py
@@ -1,7 +1,7 @@
 """
 This module defines the `PointMesh` class, which provides a 3D visualization of point meshes
 for trajectory analysis. The widget integrates with Plotly to render 3D plots and allows users
-to interact with the displayed points via a PyQt5 interface.
+to interact with the displayed points via a PyQt6 interface.
 
 The class is designed to visualize different sets of points, including local, global, and
 bundle-adjusted (BA) coordinates, which are loaded from a CSV file. Users can toggle the
@@ -12,7 +12,7 @@ Key Features:
 - Parses a CSV file containing trajectory point data.
 - Converts local points to global coordinates using provided transformation matrices.
 - Supports both original and bundle-adjusted transformation matrices.
-- Visualizes point sets in a 3D Plotly plot embedded within a PyQt5 widget.
+- Visualizes point sets in a 3D Plotly plot embedded within a PyQt6 widget.
 - Allows users to toggle visibility of different point sets using buttons.
 - Responsive resizing and dynamic updating of the plot.
 
@@ -35,10 +35,10 @@ import os
 import logging
 import pandas as pd
 import plotly.graph_objs as go
-from PyQt5.QtWidgets import QWidget, QPushButton
-from PyQt5.uic import loadUi
-from PyQt5.QtCore import Qt
-from PyQt5.QtWebEngineWidgets import QWebEngineView
+from PyQt6.QtWidgets import QWidget, QPushButton
+from PyQt6.uic import loadUi
+from PyQt6.QtCore import Qt
+from PyQt6.QtWebEngineWidgets import QWebEngineView
 from parallax.config.config_path import ui_dir
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -88,8 +88,13 @@ class PointMesh(QWidget):
         # Load the UI file and set window title
         self.ui = loadUi(os.path.join(ui_dir, "point_mesh.ui"), self)
         self.setWindowTitle(f"{self.sn} - Trajectory 3D View ")
-        self.setWindowFlags(Qt.Window | Qt.WindowMinimizeButtonHint |
-                            Qt.WindowMaximizeButtonHint | Qt.WindowCloseButtonHint)
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.Window
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
 
         # Initialize the widget
         self._set_transM(transM)

--- a/parallax/handlers/recording_manager.py
+++ b/parallax/handlers/recording_manager.py
@@ -9,9 +9,6 @@ import os
 
 # Set logger name
 logger = logging.getLogger(__name__)
-# Set the logging level for PyQt5.uic.uiparser/properties to WARNING, to ignore DEBUG messages
-logging.getLogger("PyQt5.uic.uiparser").setLevel(logging.WARNING)
-logging.getLogger("PyQt5.uic.properties").setLevel(logging.WARNING)
 
 
 class RecordingManager:

--- a/parallax/handlers/reticle_metadata.py
+++ b/parallax/handlers/reticle_metadata.py
@@ -18,9 +18,9 @@ import logging
 import json
 import numpy as np
 from scipy.spatial.transform import Rotation
-from PyQt5.QtWidgets import QWidget, QGroupBox, QLineEdit, QPushButton
-from PyQt5.uic import loadUi
-from PyQt5.QtCore import Qt
+from PyQt6.QtWidgets import QWidget, QGroupBox, QLineEdit, QPushButton
+from PyQt6.uic import loadUi
+from PyQt6.QtCore import Qt
 from parallax.config.config_path import ui_dir, reticle_metadata_file
 
 logger = logging.getLogger(__name__)
@@ -57,8 +57,13 @@ class ReticleMetadata(QWidget):
         self.ui = loadUi(os.path.join(ui_dir, "reticle_metadata.ui"), self)
         self.default_size = self.size()
         self.setWindowTitle("Reticle Metadata")
-        self.setWindowFlags(Qt.Window | Qt.WindowMinimizeButtonHint |
-                            Qt.WindowMaximizeButtonHint | Qt.WindowCloseButtonHint)
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.Window
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
 
         self.groupboxes = {}  # Change from list to dictionary
         self.reticles = {}

--- a/parallax/main_window.py
+++ b/parallax/main_window.py
@@ -4,7 +4,7 @@ including the main window, UI elements,
 camera and stage management, and recording functionality.
 
 Modules imported:
-- PyQt5 modules for building the graphical user interface.
+- PyQt6 modules for building the graphical user interface.
 - Other libraries and modules necessary for the application's functionality.
 
 Classes:
@@ -15,12 +15,12 @@ import logging
 import os
 import webbrowser
 
-from PyQt5.QtCore import QStandardPaths
-from PyQt5.QtGui import QFont, QFontDatabase
-# Import required PyQt5 modules and other libraries
-from PyQt5.QtWidgets import (QApplication, QFileDialog,
+from PyQt6.QtCore import QStandardPaths
+from PyQt6.QtGui import QFont, QFontDatabase
+# Import required PyQt6 modules and other libraries
+from PyQt6.QtWidgets import (QApplication, QFileDialog,
                              QMainWindow, QSplitter, QMessageBox)
-from PyQt5.uic import loadUi
+from PyQt6.uic import loadUi
 
 from parallax.handlers.recording_manager import RecordingManager
 from parallax.control_panel.control_panel import ControlPanel
@@ -33,9 +33,9 @@ from ui.resources import rc
 # Set logger name
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
-# Set the logging level for PyQt5.uic.uiparser/properties
-logging.getLogger("PyQt5.uic.uiparser").setLevel(logging.WARNING)
-logging.getLogger("PyQt5.uic.properties").setLevel(logging.WARNING)
+# Set the logging level for PyQt6.uic.uiparser/properties
+logging.getLogger("PyQt6.uic.uiparser").setLevel(logging.WARNING)
+logging.getLogger("PyQt6.uic.properties").setLevel(logging.WARNING)
 
 
 # Main application window
@@ -103,7 +103,9 @@ class MainWindow(QMainWindow):
         self.actionStreaming.triggered.connect(self.start_button_handler)
 
         # Fetch the default documents directory path
-        self.dir = QStandardPaths.writableLocation(QStandardPaths.DocumentsLocation)
+        self.dir = QStandardPaths.writableLocation(
+            QStandardPaths.StandardLocation.DocumentsLocation
+        )
 
         # Recording functions
         self.recordingManager = RecordingManager(self.model)
@@ -140,11 +142,11 @@ class MainWindow(QMainWindow):
             self,
             "Session Restore",
             message,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,   # default
         )
 
-        if response == QMessageBox.Yes:
+        if response == QMessageBox.StandardButton.Yes:
             logger.debug("User clicked Yes.")
             return True
         else:

--- a/parallax/model.py
+++ b/parallax/model.py
@@ -8,7 +8,7 @@ their initialization, configuration, and transformations between local and globa
 """
 import numpy as np
 from collections import OrderedDict
-from PyQt5.QtCore import QObject
+from PyQt6.QtCore import QObject
 from parallax.cameras.camera import MockCamera, PySpinCamera, close_cameras, list_cameras
 from parallax.stages.stage_listener import Stage, StageInfo
 from parallax.control_panel.probe_calibration_handler import StageCalibrationInfo

--- a/parallax/probe_calibration/probe_calibration.py
+++ b/parallax/probe_calibration/probe_calibration.py
@@ -10,7 +10,7 @@ import datetime
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt6.QtCore import QObject, pyqtSignal
 from .coords_transformation import RotationTransformation
 from .bundle_adjustment import BALProblem, BALOptimizer
 from parallax.handlers.point_mesh import PointMesh

--- a/parallax/probe_calibration/probe_calibration.py
+++ b/parallax/probe_calibration/probe_calibration.py
@@ -720,6 +720,7 @@ class ProbeCalibration(QObject):
             else:
                 return
 
+        """
         # Init PointMesh
         if not self.model.bundle_adjustment:
             self.point_mesh[sn] = PointMesh(self.model, self.file_name, sn,
@@ -728,6 +729,7 @@ class ProbeCalibration(QObject):
             self.point_mesh[sn] = PointMesh(self.model, self.file_name, sn,
                                                        self.old_transM,
                                                        self.transM_LR, calib_completed=True)
+        """
 
         # Emit the signal to indicate that calibration is complete
         self.calib_complete.emit()
@@ -743,6 +745,7 @@ class ProbeCalibration(QObject):
         Behavior:
             - If calibration is incomplete, it shows the trajectory for the current stage.
             - If calibration is complete, it displays the PointMesh instance for the 3D trajectory.
+        """
         """
         try:
             if not self.model.is_stage_calibrated(sn):
@@ -769,6 +772,9 @@ class ProbeCalibration(QObject):
                     print(f"[WARN] Restored session does not support trajectory map for {sn}.")
         except Exception as e:
             print(f"[WARN] view_3d_trajectory failed: {e}")
+        """
+        print("3D trajectory visualization is currently disabled.")
+        pass
 
     def run_bundle_adjustment(self, file_path):
         """

--- a/parallax/probe_detection/probe_detect_manager.py
+++ b/parallax/probe_detection/probe_detect_manager.py
@@ -9,7 +9,7 @@ import time
 
 import cv2
 import numpy as np
-from PyQt5.QtCore import QObject, pyqtSignal, QThreadPool, QRunnable, pyqtSlot
+from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot, QThreadPool, QRunnable
 
 from parallax.probe_detection.curr_bg_cmp_processor import CurrBgCmpProcessor
 from parallax.probe_detection.curr_prev_cmp_processor import CurrPrevCmpProcessor

--- a/parallax/reticle_detection/base_manager.py
+++ b/parallax/reticle_detection/base_manager.py
@@ -1,5 +1,5 @@
 """Base manager for reticle detection workers."""
-from PyQt5.QtCore import QObject, pyqtSignal, QThreadPool, QRunnable, pyqtSlot
+from PyQt6.QtCore import QObject, pyqtSignal, QThreadPool, QRunnable, pyqtSlot
 from parallax.config.config_path import debug_img_dir
 import time
 import numpy as np

--- a/parallax/reticle_detection/mask_generator.py
+++ b/parallax/reticle_detection/mask_generator.py
@@ -11,9 +11,6 @@ import numpy as np
 # Set logger name
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
-# Set the logging level for PyQt5.uic.uiparser/properties.
-logging.getLogger("PyQt5.uic.uiparser").setLevel(logging.WARNING)
-logging.getLogger("PyQt5.uic.properties").setLevel(logging.WARNING)
 
 
 class MaskGenerator:

--- a/parallax/reticle_detection/reticle_detection_coords_interests.py
+++ b/parallax/reticle_detection/reticle_detection_coords_interests.py
@@ -8,15 +8,15 @@ for microscopy image analysis tasks.
 import logging
 
 import numpy as np
-from PyQt5.QtCore import QObject
+from PyQt6.QtCore import QObject
 from scipy.stats import linregress
 
 # Set logger name
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
-# Set the logging level for PyQt5.uic.uiparser/properties to WARNING, to ignore DEBUG messages
-logging.getLogger("PyQt5.uic.uiparser").setLevel(logging.WARNING)
-logging.getLogger("PyQt5.uic.properties").setLevel(logging.WARNING)
+# Set the logging level for PyQt6.uic.uiparser/properties to WARNING, to ignore DEBUG messages
+logging.getLogger("PyQt6.uic.uiparser").setLevel(logging.WARNING)
+logging.getLogger("PyQt6.uic.properties").setLevel(logging.WARNING)
 
 
 class ReticleDetectCoordsInterest(QObject):

--- a/parallax/screens/axis_filter.py
+++ b/parallax/screens/axis_filter.py
@@ -9,7 +9,7 @@ import logging
 import time
 import cv2
 import numpy as np
-from PyQt5.QtCore import QObject, QThread, pyqtSignal
+from PyQt6.QtCore import QObject, QThread, pyqtSignal
 from parallax.cameras.calibration_camera import CalibrationCamera
 
 # Set logger name

--- a/parallax/screens/no_filter.py
+++ b/parallax/screens/no_filter.py
@@ -7,7 +7,7 @@ facilitating integration and optional processing steps.
 import logging
 import time
 
-from PyQt5.QtCore import QObject, QThread, pyqtSignal
+from PyQt6.QtCore import QObject, QThread, pyqtSignal
 
 # Set logger name
 logger = logging.getLogger(__name__)

--- a/parallax/screens/reticle_detect_widget.py
+++ b/parallax/screens/reticle_detect_widget.py
@@ -3,10 +3,10 @@ import os
 import logging
 import sys
 from pathlib import Path
-from PyQt5.QtWidgets import QWidget, QToolButton
-from PyQt5.QtCore import QPoint, QCoreApplication
-from PyQt5.QtGui import QFont
-from PyQt5.uic import loadUi
+from PyQt6.QtWidgets import QWidget, QToolButton
+from PyQt6.QtCore import QPoint, QCoreApplication
+from PyQt6.QtGui import QFont
+from PyQt6.uic import loadUi
 
 from parallax.config.config_path import ui_dir
 logger = logging.getLogger(__name__)

--- a/parallax/screens/screen_setting.py
+++ b/parallax/screens/screen_setting.py
@@ -1,10 +1,10 @@
 """Screen settings widget for controlling microscope camera settings."""
 import os
 import logging
-from PyQt5.QtWidgets import QWidget, QToolButton, QPushButton, QFileDialog
-from PyQt5.QtCore import QPoint, QTimer, QCoreApplication
-from PyQt5.QtGui import QFont
-from PyQt5.uic import loadUi
+from PyQt6.QtWidgets import QWidget, QToolButton, QPushButton, QFileDialog
+from PyQt6.QtCore import QPoint, QTimer, QCoreApplication
+from PyQt6.QtGui import QFont
+from PyQt6.uic import loadUi
 
 from parallax.config.config_path import ui_dir
 from parallax.config.user_setting_manager import UserSettingsManager
@@ -31,7 +31,7 @@ class ScreenSetting(QWidget):
         self.settings_refresh_timer = QTimer()  # Refreshing the settingMenu while it is toggled
         self.settings_refresh_timer.timeout.connect(self._update_setting_menu)
 
-        self._update_setting_menu()
+        #self._update_setting_menu()  #TBD
         self.settingButton.toggled.connect(
             lambda checked: self._show_settings_menu(checked)
         )
@@ -182,7 +182,7 @@ class ScreenSetting(QWidget):
         )
         self.settingMenu.wbAuto.clicked.connect(
             lambda: self.settingMenu.wbSliderRed.setValue(
-                self.screen.get_camera_setting(setting="wbRed") * 100
+                int(self.screen.get_camera_setting(setting="wbRed") * 100)
             )
         )
 
@@ -301,10 +301,12 @@ class ScreenSetting(QWidget):
                 self.settingMenu.wbSliderRed.setDisabled(False)
                 self.settingMenu.wbSliderBlue.setDisabled(False)
                 self.settingMenu.wbSliderRed.setValue(
-                    saved_settings.get("wbRed", 1.2)
+                    #saved_settings.get("wbRed", 1.2)
+                    saved_settings.get("wbRed", 1)
                 )
                 self.settingMenu.wbSliderBlue.setValue(
-                    saved_settings.get("wbBlue", 2.8)
+                    #saved_settings.get("wbBlue", 2.8)
+                    saved_settings.get("wbBlue", 3)
                 )
             elif self.screen.get_camera_color_type() == "Mono":
                 self.settingMenu.wbAuto.setDisabled(True)

--- a/parallax/screens/screen_setting.py
+++ b/parallax/screens/screen_setting.py
@@ -31,7 +31,7 @@ class ScreenSetting(QWidget):
         self.settings_refresh_timer = QTimer()  # Refreshing the settingMenu while it is toggled
         self.settings_refresh_timer.timeout.connect(self._update_setting_menu)
 
-        #self._update_setting_menu()  #TBD
+        self._update_setting_menu()
         self.settingButton.toggled.connect(
             lambda checked: self._show_settings_menu(checked)
         )
@@ -130,7 +130,7 @@ class ScreenSetting(QWidget):
         )
         self.settingMenu.gainAuto.clicked.connect(
             lambda: self.settingMenu.gainSlider.setValue(
-                self.screen.get_camera_setting(setting="gain")
+                int(self.screen.get_camera_setting(setting="gain"))
             )
         )
 
@@ -160,7 +160,7 @@ class ScreenSetting(QWidget):
         )
         self.settingMenu.wbAuto.clicked.connect(
             lambda: self.settingMenu.wbSliderBlue.setValue(
-                self.screen.get_camera_setting(setting="wbBlue") * 100
+                int(self.screen.get_camera_setting(setting="wbBlue") * 100)
             )
         )
 
@@ -280,15 +280,15 @@ class ScreenSetting(QWidget):
         saved_settings = UserSettingsManager.load_settings_item(self.sn)
         if saved_settings:
             # If saved settings are found, update the sliders in the settings menu with the saved values
-            self.settingMenu.expSlider.setValue(saved_settings.get("exp", 15))
-            self.settingMenu.gainSlider.setValue(saved_settings.get("gain", 20))
+            self.settingMenu.expSlider.setValue(int(saved_settings.get("exp", 15)))
+            self.settingMenu.gainSlider.setValue(int(saved_settings.get("gain", 20)))
 
             # Gamma
             gammaAuto = saved_settings.get("gammaAuto", None)
             if gammaAuto is True:
                 self.settingMenu.gammaSlider.setEnabled(True)
                 self.settingMenu.gammaSlider.setValue(
-                    saved_settings.get("gamma", 100)
+                    int(saved_settings.get("gamma", 100))
                 )
             elif gammaAuto is False:
                 self.settingMenu.gammaSlider.setEnabled(False)
@@ -302,11 +302,11 @@ class ScreenSetting(QWidget):
                 self.settingMenu.wbSliderBlue.setDisabled(False)
                 self.settingMenu.wbSliderRed.setValue(
                     #saved_settings.get("wbRed", 1.2)
-                    saved_settings.get("wbRed", 1)
+                    saved_settings.get("wbRed", 120)
                 )
                 self.settingMenu.wbSliderBlue.setValue(
                     #saved_settings.get("wbBlue", 2.8)
-                    saved_settings.get("wbBlue", 3)
+                    saved_settings.get("wbBlue", 280)
                 )
             elif self.screen.get_camera_color_type() == "Mono":
                 self.settingMenu.wbAuto.setDisabled(True)

--- a/parallax/screens/screen_widget.py
+++ b/parallax/screens/screen_widget.py
@@ -6,8 +6,8 @@ for real-time processing and offers camera control functions.
 
 import logging
 import pyqtgraph as pg
-from PyQt5 import QtCore
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt6 import QtCore
+from PyQt6.QtCore import Qt, pyqtSignal
 import cv2
 import numpy as np
 
@@ -20,9 +20,9 @@ from parallax.screens.axis_filter import AxisFilter
 # Set logger name
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
-# Set the logging level for PyQt5.uic.uiparser/properties to WARNING, to ignore DEBUG messages
-logging.getLogger("PyQt5.uic.uiparser").setLevel(logging.WARNING)
-logging.getLogger("PyQt5.uic.properties").setLevel(logging.WARNING)
+# Set the logging level for PyQt6.uic.uiparser/properties to WARNING, to ignore DEBUG messages
+logging.getLogger("PyQt6.uic.uiparser").setLevel(logging.WARNING)
+logging.getLogger("PyQt6.uic.properties").setLevel(logging.WARNING)
 
 
 class ScreenWidget(pg.GraphicsView):
@@ -278,6 +278,7 @@ class ScreenWidget(pg.GraphicsView):
                 val = self.camera.get_wb("Red")
             elif setting == "wbBlue":
                 val = self.camera.get_wb("Blue")
+            print("setting:", setting, "val:", val)
         return val
 
     def get_camera_color_type(self):
@@ -425,13 +426,29 @@ class ScreenWidget(pg.GraphicsView):
         else:
             return None, None
 
-    def wheelEvent(self, e):
+    def wheelEvent_deprecate(self, e):
         """
         Handle the mouse wheel event.
         """
         forward = bool(e.angleDelta().y() > 0)
         control = bool(e.modifiers() & Qt.ControlModifier)
         shift = bool(e.modifiers() & Qt.ShiftModifier)
+        if control:
+            if self.focochan:
+                foco, chan = self.focochan
+                dist = 20 if shift else 100
+                foco.time_move(chan, forward, dist, wait=True)
+        else:
+            super().wheelEvent(e)
+
+    def wheelEvent(self, e):
+        """Handle the mouse wheel event."""
+        forward = e.angleDelta().y() > 0
+
+        mods = e.modifiers()
+        control = bool(mods & Qt.KeyboardModifier.ControlModifier)
+        shift   = bool(mods & Qt.KeyboardModifier.ShiftModifier)
+
         if control:
             if self.focochan:
                 foco, chan = self.focochan

--- a/parallax/screens/screen_widget_manager.py
+++ b/parallax/screens/screen_widget_manager.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from PyQt5.QtWidgets import (
+from PyQt6.QtWidgets import (
     QGroupBox,
     QVBoxLayout,
     QWidget,
@@ -11,8 +11,8 @@ from PyQt5.QtWidgets import (
     QMainWindow,
     QDockWidget,
 )
-from PyQt5.QtGui import QFont, QIcon
-from PyQt5.QtCore import Qt, QTimer, QEvent, QObject
+from PyQt6.QtGui import QFont, QIcon
+from PyQt6.QtCore import Qt, QTimer, QEvent, QObject
 
 from parallax.screens.screen_widget import ScreenWidget
 from parallax.screens.screen_setting import ScreenSetting
@@ -115,18 +115,18 @@ class ScreenWidgetManager(QObject):
         layout.addWidget(screen)
 
         # Bottom row with buttons
-        screen_setting = ScreenSetting(parent=group_box, model=self.model, screen=screen)
+        #screen_setting = ScreenSetting(parent=group_box, model=self.model, screen=screen)  #TBD
         reticle_detector = ReticleDetectWidget(parent=group_box, model=self.model, screen=screen)
         button_row = QHBoxLayout()
-        button_row.setAlignment(Qt.AlignLeft)
-        button_row.addWidget(screen_setting.settingButton)
+        button_row.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        #button_row.addWidget(screen_setting.settingButton)
         button_row.addWidget(reticle_detector.detectButton)
         layout.addLayout(button_row)
 
         # Create QDockWidget
         dock = QDockWidget(name, self.main_window)
         dock.setWidget(group_box)
-        dock.setAllowedAreas(Qt.LeftDockWidgetArea)
+        dock.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea)
         dock.setObjectName(name)
         dock.setFloating(False)
         dock.setMinimumWidth(300)
@@ -143,7 +143,7 @@ class ScreenWidgetManager(QObject):
             self._toggle_streaming(visible, sn)
 
         dock.visibilityChanged.connect(sync_action_to_dock_visibility)
-        self.main_window.addDockWidget(Qt.LeftDockWidgetArea, dock)
+        self.main_window.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, dock)
 
         self.screen_widgets.append(screen)
         self.dock_widgets.append((name, dock))

--- a/parallax/screens/screen_widget_manager.py
+++ b/parallax/screens/screen_widget_manager.py
@@ -115,11 +115,11 @@ class ScreenWidgetManager(QObject):
         layout.addWidget(screen)
 
         # Bottom row with buttons
-        #screen_setting = ScreenSetting(parent=group_box, model=self.model, screen=screen)  #TBD
+        screen_setting = ScreenSetting(parent=group_box, model=self.model, screen=screen)
         reticle_detector = ReticleDetectWidget(parent=group_box, model=self.model, screen=screen)
         button_row = QHBoxLayout()
         button_row.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        #button_row.addWidget(screen_setting.settingButton)
+        button_row.addWidget(screen_setting.settingButton)
         button_row.addWidget(reticle_detector.detectButton)
         layout.addLayout(button_row)
 

--- a/parallax/stages/stage_controller.py
+++ b/parallax/stages/stage_controller.py
@@ -19,7 +19,7 @@ import requests
 import json
 import numpy as np
 from typing import Optional
-from PyQt5.QtCore import QObject, QTimer
+from PyQt6.QtCore import QObject, QTimer
 from parallax.utils.coords_converter import CoordsConverter
 
 # Set logger name

--- a/parallax/stages/stage_http_server.py
+++ b/parallax/stages/stage_http_server.py
@@ -6,7 +6,6 @@ import logging
 import json
 import asyncio
 import threading
-from PyQt5.QtCore import QObject
 from aiohttp import web
 
 from .stage_controller import StageController
@@ -16,7 +15,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
 
-class StageHttpServer(QObject):
+class StageHttpServer():
     """Manages the Stage HTTP Server using aiohttp (Fully Async)"""
 
     def __init__(self, model, stages_info, port=8081):

--- a/parallax/stages/stage_listener.py
+++ b/parallax/stages/stage_listener.py
@@ -1,6 +1,6 @@
 """
 Provides classes to manage stage data fetching, representation, and updates in microscopy
-applications, using PyQt5 for threading and signals, and requests for HTTP requests.
+applications, using PyQt6 for threading and signals, and requests for HTTP requests.
 """
 import os
 import json
@@ -12,8 +12,8 @@ from datetime import datetime
 from typing import Optional, Dict, Any
 from dataclasses import dataclass
 
-from PyQt5.QtCore import QObject, QThread, QTimer, pyqtSignal
-from PyQt5.QtWidgets import QFileDialog
+from PyQt6.QtCore import QObject, QThread, QTimer, pyqtSignal
+from PyQt6.QtWidgets import QFileDialog
 from parallax.utils.coords_converter import CoordsConverter
 
 # Set logger name

--- a/parallax/stages/stage_server_ipconfig.py
+++ b/parallax/stages/stage_server_ipconfig.py
@@ -10,9 +10,9 @@ to apply the configuration dynamically.
 import os
 import json
 import logging
-from PyQt5.QtWidgets import QWidget
-from PyQt5.uic import loadUi
-from PyQt5.QtCore import Qt
+from PyQt6.QtWidgets import QWidget
+from PyQt6.uic import loadUi
+from PyQt6.QtCore import Qt
 from parallax.config.config_path import ui_dir, stage_server_config_file
 
 logger = logging.getLogger(__name__)
@@ -37,8 +37,13 @@ class StageServerIPConfig(QWidget):
 
         self.ui = loadUi(os.path.join(ui_dir, "stage_server.ui"), self)
         self.setWindowTitle("Stage Server IP Configuration")
-        self.setWindowFlags(Qt.Window | Qt.WindowMinimizeButtonHint |
-                            Qt.WindowMaximizeButtonHint | Qt.WindowCloseButtonHint)
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowType.Window
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint   # include if you want it
+            | Qt.WindowType.WindowCloseButtonHint
+        )
 
         # Load saved IP and port from JSON file
         self._load_url_from_json()

--- a/parallax/stages/stage_ui.py
+++ b/parallax/stages/stage_ui.py
@@ -1,11 +1,11 @@
 """
-Defines StageUI, a PyQt5 QWidget for showing and updating stage information in the UI,
+Defines StageUI, a PyQt6 QWidget for showing and updating stage information in the UI,
 including serial numbers and coordinates. It interacts with the model to reflect
 real-time data changes.
 """
 
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QWidget
+from PyQt6.QtCore import pyqtSignal
 import numpy as np
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "pip",
-    "PyQt5>=5.15",
+    "PyQt6",
     "pyqtgraph",
     "opencv-python",
     "scipy",
@@ -28,7 +28,7 @@ dependencies = [
     "requests",
     "scikit-learn",
     "plotly",
-    "PyQtWebEngine",
+    "PyQt6-WebEngine==6.9.0",
     "aiohttp",
     "pyyaml"
    ]
@@ -46,7 +46,6 @@ readme = {file = "README.md"}
  
 [project.optional-dependencies]
 dev = ['parallax-app[linters]']
-camera = ["spinnaker-python"]
 
 linters = [
     'codespell',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license =  {text = "MIT"}
 readme = "README.md"
 keywords = ["parallax"]
 dynamic = ["version"]
-requires-python = "~=3.8"
+requires-python = "~=3.10"
 classifiers = [
     "Programming Language :: Python :: 3"
 ]
@@ -28,7 +28,7 @@ dependencies = [
     "requests",
     "scikit-learn",
     "plotly",
-    "PyQt6-WebEngine==6.9.0",
+    "PyQt6-WebEngine",
     "aiohttp",
     "pyyaml"
    ]

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import MagicMock, Mock
 
 # ---- Qt imports kept local to tests ----
-from PyQt5.QtWidgets import (
+from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QGroupBox, QPushButton,
     QLineEdit, QLabel, QComboBox
 )

--- a/tests/test_axis_filter.py
+++ b/tests/test_axis_filter.py
@@ -3,7 +3,7 @@ import numpy as np
 import time
 from unittest.mock import Mock
 from parallax.screens.axis_filter import AxisFilter
-from PyQt5.QtCore import QCoreApplication, QEventLoop
+from PyQt6.QtCore import QCoreApplication, QEventLoop
 
 @pytest.fixture
 def reticle_coords():

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from unittest.mock import MagicMock
-from PyQt5.QtWidgets import QWidget, QGroupBox, QVBoxLayout, QPushButton, QLineEdit, QComboBox, QLabel
+from PyQt6.QtWidgets import QWidget, QGroupBox, QVBoxLayout, QPushButton, QLineEdit, QComboBox, QLabel
 import parallax.handlers.calculator as calc_mod
 from parallax.handlers.calculator import Calculator
 

--- a/tests/test_probe_calibration.py
+++ b/tests/test_probe_calibration.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import pandas as pd
-from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt6.QtCore import QObject, pyqtSignal
 from parallax.probe_calibration.probe_calibration import ProbeCalibration
 from parallax.model import Model  # Replace with the actual class that represents the model
 

--- a/tests/test_reticle_metadata.py
+++ b/tests/test_reticle_metadata.py
@@ -1,5 +1,5 @@
 import numpy as np
-from PyQt5.QtWidgets import QComboBox, QWidget
+from PyQt6.QtWidgets import QComboBox, QWidget
 from unittest.mock import Mock
 import pytest
 
@@ -31,69 +31,3 @@ def reticle_metadata(qtbot, model):
     # If ReticleMetadata is a QWidget subclass, also do: qtbot.addWidget(rm)
 
     yield rm
-
-"""
-
-def test_add_reticle(reticle_metadata):
-    initial_count = len(reticle_metadata.groupboxes)
-    reticle_metadata._add_groupbox()
-    assert len(reticle_metadata.groupboxes) == initial_count + 1
-    added_name = list(reticle_metadata.groupboxes.keys())[-1]
-    assert added_name.isalpha() and len(added_name) == 1
-
-def test_remove_reticle(reticle_metadata):
-    reticle_metadata._add_groupbox()
-    initial_count = len(reticle_metadata.groupboxes)
-    added_name = list(reticle_metadata.groupboxes.keys())[-1]
-    group_box = reticle_metadata.groupboxes[added_name]
-    reticle_metadata._remove_specific_groupbox(group_box)
-    assert len(reticle_metadata.groupboxes) == initial_count - 1
-    assert added_name not in reticle_metadata.groupboxes
-
-def test_update_reticle_info(reticle_metadata):
-    from PyQt5.QtWidgets import QLineEdit
-    reticle_metadata._add_groupbox()
-    reticle_name = list(reticle_metadata.groupboxes.keys())[-1]
-    group_box = reticle_metadata.groupboxes[reticle_name]
-
-    rotation_field = group_box.findChild(QLineEdit, "lineEditRot")
-    offset_x_field = group_box.findChild(QLineEdit, "lineEditOffsetX")
-    offset_y_field = group_box.findChild(QLineEdit, "lineEditOffsetY")
-    offset_z_field = group_box.findChild(QLineEdit, "lineEditOffsetZ")
-
-    rotation_field.setText("45")
-    offset_x_field.setText("10")
-    offset_y_field.setText("20")
-    offset_z_field.setText("30")
-
-    reticle_metadata._update_reticles(group_box)
-
-    reticle_data = reticle_metadata.reticles[reticle_name]
-    assert reticle_data["rot"] == 45.0
-    assert reticle_data["offset_x"] == 10.0
-    assert reticle_data["offset_y"] == 20.0
-    assert reticle_data["offset_z"] == 30.0
-
-def test_get_global_coords_with_offset(reticle_metadata):
-    from PyQt5.QtWidgets import QLineEdit
-    reticle_metadata._add_groupbox()
-    reticle_name = list(reticle_metadata.groupboxes.keys())[-1]
-    group_box = reticle_metadata.groupboxes[reticle_name]
-
-    rotation_field = group_box.findChild(QLineEdit, "lineEditRot")
-    offset_x_field = group_box.findChild(QLineEdit, "lineEditOffsetX")
-    offset_y_field = group_box.findChild(QLineEdit, "lineEditOffsetY")
-    offset_z_field = group_box.findChild(QLineEdit, "lineEditOffsetZ")
-
-    rotation_field.setText("90")
-    offset_x_field.setText("10")
-    offset_y_field.setText("0")
-    offset_z_field.setText("5")
-
-    reticle_metadata._update_reticles(group_box)
-
-    global_pts = np.array([1, 0, 0])
-    gx, gy, gz = reticle_metadata.get_global_coords_with_offset(reticle_name, global_pts)
-    assert (gx, gy, gz) == (10.0, 1.0, 5.0)
-
-"""

--- a/tests/test_screen_coords_mapper.py
+++ b/tests/test_screen_coords_mapper.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from PyQt5.QtWidgets import QLineEdit, QComboBox, QWidget, QVBoxLayout
+from PyQt6.QtWidgets import QLineEdit, QComboBox, QWidget, QVBoxLayout
 from parallax.handlers.screen_coords_mapper import ScreenCoordsMapper
 
 # --- Minimal mocks ------------------------------------------------------------

--- a/tests/test_screen_widget.py
+++ b/tests/test_screen_widget.py
@@ -1,7 +1,7 @@
 # tests/test_stage_widget.py
 import pytest
 from unittest.mock import Mock
-from PyQt5.QtWidgets import QWidget
+from PyQt6.QtWidgets import QWidget
 
 class DummySignal:
     def __init__(self): self._slots = []

--- a/tests/test_stage_server_ipconfig.py
+++ b/tests/test_stage_server_ipconfig.py
@@ -3,7 +3,7 @@ import os
 import json
 import pytest
 from unittest.mock import MagicMock
-from PyQt5.QtWidgets import QLineEdit
+from PyQt6.QtWidgets import QLineEdit
 from parallax.stages.stage_server_ipconfig import StageServerIPConfig
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "test_data", "stage_server_ipconfig")

--- a/tests/test_stage_ui.py
+++ b/tests/test_stage_ui.py
@@ -1,6 +1,6 @@
 # tests/test_stage_ui.py
 import pytest
-from PyQt5.QtWidgets import QWidget, QComboBox, QLabel, QLineEdit, QVBoxLayout
+from PyQt6.QtWidgets import QWidget, QComboBox, QLabel, QLineEdit, QVBoxLayout
 from unittest.mock import Mock
 
 from parallax.stages.stage_ui import StageUI

--- a/ui/resources/rc.py
+++ b/ui/resources/rc.py
@@ -2,11 +2,11 @@
 
 # Resource object code
 #
-# Created by: The Resource Compiler for PyQt5 (Qt v5.15.2)
+# Created by: The Resource Compiler for PyQt6 (Qt v6.2.0)
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore
+from PyQt6 import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x01\xb4\


### PR DESCRIPTION
### Changes
- Upgraded Python support: 3.8 → 3.10
- Migrated GUI from PyQt5 → PyQt6
- Added instructions for installing the Spinnaker SDK (ReadMe)

### Notes
- The [sfm](https://github.com/AllenNeuralDynamics/sfm) repo, detecting reticle and localization of camera, now supports both Python 3.8 and 3.10.

- User Documentation should be updated; will be fixed before merging into `main`
- Viewing the probe-tracking trajectory is currently under investigation; the PyQt6 upgrade temporarily prevents it from working properly (pyqt web engine usage). Will be fixed this before merging into `main`.
- Some `pytest` tests are currently failing due to the PyQt6 migration; we’ll address these before merging into `main`.
