### PR TITLE
Reticle calibration button does not clear calib results

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/control_panel/probe_calibration_handler.py
+++ b/parallax/control_panel/probe_calibration_handler.py
@@ -179,8 +179,9 @@ class ProbeCalibrationHandler(QWidget):
 
     def reticle_detection_status_change(self):
         """Updates the reticle detection status and performs actions based on the new status."""
-        if self.model.reticle_detection_status == "default":
-            self.probe_detect_default_status()
+        # TODO Test for camera-pairs logic
+        #if self.model.reticle_detection_status == "default":
+        #    self.probe_detect_default_status()
         if self.model.reticle_detection_status == "accepted":
             self.enable_probe_calibration_btn()
 

--- a/parallax/control_panel/reticle_detect_handler.py
+++ b/parallax/control_panel/reticle_detect_handler.py
@@ -122,7 +122,8 @@ class ReticleDetecthandler(QWidget):
         self.reticleCalibrationLabel.setText("")
         self.triangulate_btn.setChecked(False)
 
-        self.model.reset_stage_calib_info()
+        # TODO Test for camera-pairs logic
+        #self.model.reset_stage_calib_info()
         self.model.reset_all_triangulation_partners()
 
         # Enable triangulate_btn button

--- a/parallax/stages/stage_ui.py
+++ b/parallax/stages/stage_ui.py
@@ -223,4 +223,6 @@ class StageUI(QWidget):
             status (str): The new status of the reticle detection.
         """
         if self.model.reticle_detection_status == "default":
-            self.updateStageGlobalCoords_default()
+            pass
+            # TODO Test for camera-pairs logic
+            #self.updateStageGlobalCoords_default()


### PR DESCRIPTION
Reticle calibration button does not clear stage calibration results.
User can select different stereo paris during the session.  