### PR TITLE
Dev

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.16.0"
+__version__ = "1.16.1"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/cameras/camera_base_binding.py
+++ b/parallax/cameras/camera_base_binding.py
@@ -56,8 +56,12 @@ class BaseSettings(ABC):
         """Returns the minimum allowed exposure time."""
         return -1.0
 
-    def set_exposure_time_lower_limit(self, lower_limit: float) -> None:
+    def set_exposure_time_lower_limit(self, lower_limit_us: float) -> None:
         """Sets the minimum allowed exposure time."""
+        pass
+
+    def set_exposure_time_upper_limit(self, upper_limit_us: float) -> None:
+        """Sets the maximum allowed exposure time."""
         pass
 
     # ------------------------------------------------------------------
@@ -79,11 +83,11 @@ class BaseSettings(ABC):
         """Sets auto gain mode."""
         pass
 
-    def set_auto_gain_lower_limit(self, target_limit_db: float) -> None:
+    def set_auto_gain_lower_limit(self, lower_limit_db: float) -> None:
         """Sets the lower limit for gain if supported by the camera."""
         pass
 
-    def set_auto_gain_upper_limit(self, target_limit_db: float) -> None:
+    def set_auto_gain_upper_limit(self, upper_limit_db: float) -> None:
         """Sets the upper limit for gain if supported by the camera."""
         pass
 

--- a/parallax/cameras/settings.py
+++ b/parallax/cameras/settings.py
@@ -490,9 +490,6 @@ class MockSettings(BaseSettings):
     def get_exposure_time_lower_limit(self):
         return 1.0
 
-    def set_exposure_time_upper_limit(self, upper_limit):
-        pass  # Not implemented in mock
-
     # --- Frame Rate ---
     def get_frame_rate(self):
         return self._frame_rate


### PR DESCRIPTION
This PR updates the camera settings abstraction to better align method argument names with PySpin’s APIs and increments the package version.

Changes:

- Renamed BaseSettings method parameters for exposure/gain auto-limit setters to use clearer, unit-explicit names (e.g., *_us, *_db).
- Added set_exposure_time_upper_limit(upper_limit_us) to BaseSettings.
- Bumped package version to 1.16.1.