### PR TITLE
Fix bug) MPM stage server port update

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -4,7 +4,7 @@ Init
 
 import os
 
-__version__ = "1.16.1"
+__version__ = "1.16.2"
 
 # allow multiple OpenMP instances
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"

--- a/parallax/control_panel/control_panel.py
+++ b/parallax/control_panel/control_panel.py
@@ -173,11 +173,11 @@ class ControlPanel(QWidget):
 
     def refresh_stages(self):
         """Refreshes the stages using the updated server configuration."""
-        print("Refreshing stages with updated server configuration...")
         # If URL is not updated or invalid, do nothing
         if not self.stage_server_ipconfig.update_url():
             return
 
+        print("Refreshing stages with updated server configuration...")
         # refresh the stage using server IP address
         self.stage_server_ipconfig.refresh_stages()  # Update stages server url to model # models.transforms updated
         self.stageUI.initialize()
@@ -190,7 +190,6 @@ class ControlPanel(QWidget):
 
         # Update url on StageLinstener
         self.stageListener.update_url()
-        print("Stages refreshed successfully.")
 
     def stage_server_ipconfig_btn_handler(self):
         """

--- a/parallax/control_panel/probe_calibration_handler.py
+++ b/parallax/control_panel/probe_calibration_handler.py
@@ -467,7 +467,7 @@ class ProbeCalibrationHandler(QWidget):
             # Reset the probe calibration status
             self.clearRequested.emit(self.selected_stage_id)
             # update global coords. Set  to '-' on UI
-        else:  # Reset all probel calibration status
+        else:  # Reset all probe calibration status
             for stage_sn in self.model.get_list_of_stage_sns():
                 self.clearRequested.emit(stage_sn)
 

--- a/parallax/control_panel/probe_calibration_handler.py
+++ b/parallax/control_panel/probe_calibration_handler.py
@@ -468,8 +468,8 @@ class ProbeCalibrationHandler(QWidget):
             self.clearRequested.emit(self.selected_stage_id)
             # update global coords. Set  to '-' on UI
         else:  # Reset all probel calibration status
-            for sn in self.model.get_list_of_stage_sns():
-                self.clearRequested.emit(self.selected_stage_id)
+            for stage_sn in self.model.get_list_of_stage_sns():
+                self.clearRequested.emit(stage_sn)
 
         # Set as Uncalibrated
         self.calculator.set_calc_functions()

--- a/parallax/handlers/calculator.py
+++ b/parallax/handlers/calculator.py
@@ -273,6 +273,9 @@ class Calculator(QWidget):
         """
         if not sn:
             return
+        if self.findChild(QGroupBox, f"groupBox_{sn}") is None:
+            print("Error: Group box not found")
+            return
         # Clear the QLineEdit for the stage
         self.findChild(QLineEdit, f"localX_{sn}").setText("")
         self.findChild(QLineEdit, f"localY_{sn}").setText("")

--- a/parallax/model.py
+++ b/parallax/model.py
@@ -88,11 +88,12 @@ class Model:
         print("Scanning for USB stages...")
         server = PathfinderServer(self.config.pathfinder_server.url)
         instances = server.get_instances()
+        self.stage_instances = {}  # Reset internal state before updating
         for instance in instances:
             stage = StageObj.from_info(info=instance)
-            sn = stage.sn
-            self.stage_instances[sn] = stage
+            self.stage_instances[stage.sn] = stage
         self.nStages = len(self.stage_instances)
+        self.instantiate_session()  # Sync with session after scanning
         print("  Stages:", list(self.stage_instances.keys()))
 
     # =========================

--- a/parallax/model.py
+++ b/parallax/model.py
@@ -133,10 +133,12 @@ class Model:
         return self.stage_instances.get(sn)
 
     def reset_stage_obj_info(self, sn: str):
-        self.stage_instances.get(sn).stage_x_global = None
-        self.stage_instances.get(sn).stage_y_global = None
-        self.stage_instances.get(sn).stage_z_global = None
-        self.stage_instances.get(sn).stage_bregma = None
+        stage_obj = self.stage_instances.get(sn)
+        if stage_obj is not None:
+            stage_obj.stage_x_global = None
+            stage_obj.stage_y_global = None
+            stage_obj.stage_z_global = None
+            stage_obj.stage_bregma = None
 
     # =========================
     # Stages calibration

--- a/parallax/stages/stage_listener.py
+++ b/parallax/stages/stage_listener.py
@@ -256,7 +256,7 @@ class StageListener:
         # Stop the current worker
         if self.worker.is_alive():
             self.worker.stop()
-            self.worker.join(timeout=1.0) # Wait for it to exit
+            self.worker.join(timeout=1.0)  # Wait for it to exit
 
         # Create a new worker with the updated URL
         new_url = self.model.config.pathfinder_server.url

--- a/parallax/stages/stage_listener.py
+++ b/parallax/stages/stage_listener.py
@@ -15,34 +15,21 @@ logger.setLevel(logging.WARNING)
 
 
 class PathfinderServer:
-    """Retrieve and manage information about the stages."""
+    """Utility to fetch stage information from the hardware server."""
 
     def __init__(self, url: str):
-        """Initialize StageInfo."""
         self.url = url
-        self.nStages = 0
-        self.stages_sn = []
 
     def get_instances(self) -> list:
-        """Get the instances of the stages.
-
-        Returns:
-            list: List of stage instance dicts.
-        """
-        stages = []
+        """Fetch raw list of stages from the server."""
         try:
             response = requests.get(self.url, timeout=1)
             if response.status_code == 200:
-                data = response.json()
-                self.nStages = data.get("Probes", 0)
-                for stage in data.get("ProbeArray", []):
-                    self.stages_sn.append(stage["SerialNumber"])
-                    stages.append(stage)
+                return response.json().get("ProbeArray", [])
         except Exception as e:
-            print("Stage HttpServer not enabled.")
             logger.debug(f"Stage HttpServer not enabled: {e}")
 
-        return stages
+        return []
 
 
 class Worker(threading.Thread):
@@ -77,6 +64,7 @@ class Worker(threading.Thread):
     def update_url(self, url):
         """Change the URL for data fetching."""
         self.url = url
+        self.is_error_log_printed = False
 
     def run(self):
         """The main loop of the native thread with crash protection."""
@@ -264,5 +252,22 @@ class StageListener:
             probeDetector.enable_calibration(self.worker.last_move_detected_time + self.worker.IDLE_TIME, sn)
 
     def update_url(self):
-        """Update the URL for the worker thread."""
-        self.worker.update_url(self.model.config.pathfinder_server.url)
+        """Stop the old thread and start a fresh one with the new URL."""
+        # Stop the current worker
+        if self.worker.is_alive():
+            self.worker.stop()
+            self.worker.join(timeout=1.0) # Wait for it to exit
+
+        # Create a new worker with the updated URL
+        new_url = self.model.config.pathfinder_server.url
+        self.worker = Worker(new_url)
+
+        # Re-connect the signals to the new worker
+        self.worker.dataChanged.connect(self.handleDataChange)
+        self.worker.stage_moving.connect(self.stageMovingStatus)
+        self.worker.stage_not_moving.connect(self.stageNotMovingStatus)
+
+        # Start the new worker
+        self.worker.start()
+
+        print(f"Stage Listener restarted with URL: {new_url}")

--- a/parallax/stages/stage_listener.py
+++ b/parallax/stages/stage_listener.py
@@ -256,7 +256,12 @@ class StageListener:
         # Stop the current worker
         if self.worker.is_alive():
             self.worker.stop()
-            self.worker.join(timeout=1.0)  # Wait for it to exit
+            if not self.worker.join(timeout=2.0):
+                # If it doesn't join, it's safer to just update the URL
+                # rather than force-killing or starting a second thread.
+                logger.warning("Worker failed to join; falling back to URL update.")
+                self.worker.update_url(self.model.config.pathfinder_server.url)
+                return
 
         # Create a new worker with the updated URL
         new_url = self.model.config.pathfinder_server.url

--- a/parallax/stages/stage_ui.py
+++ b/parallax/stages/stage_ui.py
@@ -30,9 +30,9 @@ class StageUI(QWidget):
         self.previous_stage_id = None
 
         # initialize UI
-        self._initialize()
+        self.initialize()
 
-    def _initialize(self):
+    def initialize(self):
         """Initialize the stage UI with current state."""
         # 1. Block signals while building the list
         self.ui.stage_selector.blockSignals(True)


### PR DESCRIPTION
**Fix Threading Bug:** Refactored StageListener.update_url to stop and restart the Worker thread (stage listener) rather than patching a running thread. This refreshes MPM stage server when ports change.

etc)
- Crash Prevention: Added None checks for UI elements (QGroupBox, QLineEdit) in calculator.py and model.py to prevent AttributeError during initialization and refresh cycles.
- Refactored PathfinderServer to be stateless.
- UI/Refactoring: Renamed private method _initialize to initialize in StageUI for accessibility.

<img width="150" height="200" alt="image" src="https://github.com/user-attachments/assets/9618a1bf-0cc1-46cd-936f-839626025b05" />
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/5b078a62-b39f-4598-ada7-837e0edc10e6" />
